### PR TITLE
fix missing coma in a query

### DIFF
--- a/omero_mapr/tree.py
+++ b/omero_mapr/tree.py
@@ -722,16 +722,18 @@ def marshal_images(conn, parent, parent_id,
 
     extra_values = []
     if load_pixels:
-        extra_values.append(
-            " , "
-            " pix.sizeX as sizeX, "
-            " pix.sizeY as sizeY, "
-            " pix.sizeZ as sizeZ ")
+        extra_values.append("""
+            ,
+            pix.sizeX as sizeX,
+            pix.sizeY as sizeY,
+            pix.sizeZ as sizeZ
+        """)
 
     if date:
-        extra_values.append(
-            " image.details.creationEvent.time as date, "
-            "image.acquisitionDate as acqDate")
+        extra_values.append(""",
+            image.details.creationEvent.time as date,
+            image.acquisitionDate as acqDate
+        """)
 
     q = """
         select new map(image.id as id,


### PR DESCRIPTION
this fixes Illegal query reported in https://docs.google.com/spreadsheets/d/1uPbSD4NtwEiH3S6-ijsARDLGg--816LExE4BByMH0Cc/edit#gid=385968527

test for example http://ebi-embassy-cherry.openmicroscopy.org/mapr/gene/?value=NUP107