### PR TITLE
load case insensitive data to the tree

### DIFF
--- a/omero_mapr/__init__.py
+++ b/omero_mapr/__init__.py
@@ -26,7 +26,7 @@
 from omero_mapr.utils.version import get_version
 
 
-VERSION = (0, 1, 10)
+VERSION = (0, 1, 11)
 
 __version__ = get_version(VERSION)
 

--- a/omero_mapr/static/mapr/css/ome.mapr.css
+++ b/omero_mapr/static/mapr/css/ome.mapr.css
@@ -36,3 +36,31 @@ ul.ui-autocomplete{
 input[type='text'].ui-autocomplete-loading {
     background: url('../../webgateway/img/spinner.gif') no-repeat right center;
 }
+
+
+div label input {
+    margin-right:100px;
+}
+body {
+    font-family:sans-serif;
+}
+
+
+
+.case_sensitive input[type=checkbox] {
+    display:none;
+}
+.case_sensitive label {
+    color:hsl(215,20%,75%);
+    font-size: 1.3em;
+    font-weight: lighter;
+    display:inline-block;
+    width: 16px;
+    height: 16px;
+    padding: 5px 0px;
+    margin: 2px;
+}
+
+.case_sensitive input[type=checkbox]:checked + label {
+    color:#555555;
+}

--- a/omero_mapr/static/mapr/css/ome.mapr.css
+++ b/omero_mapr/static/mapr/css/ome.mapr.css
@@ -48,17 +48,17 @@ body {
 
 
 .case_sensitive input[type=checkbox] {
-    display:none;
+    display: inline-block;
+    vertical-align: middle;
 }
 .case_sensitive label {
-    color:hsl(215,20%,75%);
-    font-size: 1.3em;
+    color: hsl(215,20%,75%);
     font-weight: lighter;
-    display:inline-block;
-    width: 16px;
+    display: inline-block;
+    width: 25px;
     height: 16px;
     padding: 5px 0px;
-    margin: 2px;
+    vertical-align: middle;
 }
 
 .case_sensitive input[type=checkbox]:checked + label {

--- a/omero_mapr/static/mapr/css/ome.mapr.css
+++ b/omero_mapr/static/mapr/css/ome.mapr.css
@@ -60,3 +60,6 @@ body {
     padding: 5px 0px;
     vertical-align: middle;
 }
+.case_sensitive input[type=checkbox][disabled] + label{
+    color: hsl(215,20%,75%);
+}

--- a/omero_mapr/static/mapr/css/ome.mapr.css
+++ b/omero_mapr/static/mapr/css/ome.mapr.css
@@ -52,15 +52,11 @@ body {
     vertical-align: middle;
 }
 .case_sensitive label {
-    color: hsl(215,20%,75%);
+    color: #555555;
     font-weight: lighter;
     display: inline-block;
     width: 25px;
     height: 16px;
     padding: 5px 0px;
     vertical-align: middle;
-}
-
-.case_sensitive input[type=checkbox]:checked + label {
-    color:#555555;
 }

--- a/omero_mapr/static/mapr/javascript/ome.mapr.js
+++ b/omero_mapr/static/mapr/javascript/ome.mapr.js
@@ -36,6 +36,9 @@ $(function () {
         if (MAPANNOTATIONS.CTX.value.length > 0) {
             payload['value'] = MAPANNOTATIONS.CTX.value;
         }
+        if (MAPANNOTATIONS.CTX.case_sensitive.length > 0) {
+            payload['case_sensitive'] = MAPANNOTATIONS.CTX.case_sensitive;
+        }
         // only support matching results in a JSTree
         //if (MAPANNOTATIONS.CTX.query) {
         //    payload['query'] = MAPANNOTATIONS.CTX.query;

--- a/omero_mapr/static/mapr/javascript/ome.mapr.js
+++ b/omero_mapr/static/mapr/javascript/ome.mapr.js
@@ -36,10 +36,11 @@ $(function () {
         if (MAPANNOTATIONS.CTX.value.length > 0) {
             payload['value'] = MAPANNOTATIONS.CTX.value;
         }
-        if (MAPANNOTATIONS.CTX.case_sensitive.length > 0) {
-            payload['case_sensitive'] = MAPANNOTATIONS.CTX.case_sensitive;
-        }
-        // only support matching results in a JSTree
+        // case sensitive results in a JSTree
+        //if (MAPANNOTATIONS.CTX.case_sensitive.length > 0) {
+        //    payload['case_sensitive'] = MAPANNOTATIONS.CTX.case_sensitive;
+        //}
+        // query results in a JSTree
         //if (MAPANNOTATIONS.CTX.query) {
         //    payload['query'] = MAPANNOTATIONS.CTX.query;
         //}

--- a/omero_mapr/static/mapr/javascript/ome.mapr.ui.autocomplete.js
+++ b/omero_mapr/static/mapr/javascript/ome.mapr.ui.autocomplete.js
@@ -85,7 +85,7 @@ $(function () {
             .appendTo( ul );
     }
 
-    $("#search_hints").tooltip({
+    $(".mapr_tooltip").tooltip({
         track: true,
         show: false,
         hide: false,

--- a/omero_mapr/static/mapr/javascript/ome.mapr.ui.autocomplete.js
+++ b/omero_mapr/static/mapr/javascript/ome.mapr.ui.autocomplete.js
@@ -59,14 +59,18 @@ $(function () {
         },
         minLength: 1,
         open: function() {},
-        close: function() {},
+        close: function() {
+            $(this).val('');
+            $(this).data().uiAutocomplete.term = null;
+            return false;
+        },
         focus: function(event,ui) {},
         select: function(event, ui) {
             if (ui.item.value == -1) {
                 return false;
             }
-            // keep selected value in input
-            $( "#id_autocomplete" ).val("");
+            $(this).val('');
+            $(this).data().uiAutocomplete.term = null;
             jstreeInst.deselect_all();
             jstreeInst.close_all();
             OME.clearThumbnailsPanel();

--- a/omero_mapr/static/mapr/javascript/ome.mapr.ui.autocomplete.js
+++ b/omero_mapr/static/mapr/javascript/ome.mapr.ui.autocomplete.js
@@ -37,10 +37,11 @@ $(function () {
                 type : 'GET',
                 url: MAPANNOTATIONS.URLS.autocomplete,
                 data: {
-                    value: request.term.toLowerCase(),
+                    case_sensitive: $('#id_case_sensitive').is(":checked"),
+                    value: $('#id_case_sensitive').is(":checked") ? request.term : request.term.toLowerCase(),
                     query: true,
                     experimenter_id: WEBCLIENT.active_user,
-                    group: WEBCLIENT.active_group_id
+                    group: WEBCLIENT.active_group_id,
                 },
                 success: function(data) {
                     if (data.length > 0) {
@@ -49,7 +50,7 @@ $(function () {
                         }));
                     } else {
                        response([{ label: 'No results found.', value: -1 }]);
-                   }
+                    }
                 },
                 error: function(data) {
                     response([{ label: 'Error occured.', value: -1 }]);

--- a/omero_mapr/static/mapr/javascript/ome.mapr.ui.autocomplete.js
+++ b/omero_mapr/static/mapr/javascript/ome.mapr.ui.autocomplete.js
@@ -72,7 +72,9 @@ $(function () {
             OME.clearThumbnailsPanel();
             WEBCLIENT.URLS.api_experimenter = MAPANNOTATIONS.URLS.autocomplete_default
             jstreeInst.settings.core.data = function(node, callback, payload) {
-                oldData.apply(jstreeInst, [node, callback, {'value': ui.item.value}]);
+                oldData.apply(jstreeInst, [node, callback,
+                    {'value': ui.item.value,
+                     'case_sensitive': $('#id_case_sensitive').is(":checked")}]);
             };
             jstreeInst.refresh();
             return false;

--- a/omero_mapr/static/mapr/javascript/ome.mapr.ui.autocomplete.js
+++ b/omero_mapr/static/mapr/javascript/ome.mapr.ui.autocomplete.js
@@ -37,9 +37,9 @@ $(function () {
                 type : 'GET',
                 url: MAPANNOTATIONS.URLS.autocomplete,
                 data: {
-                    case_sensitive: $('#id_case_sensitive').is(":checked"),
                     value: $('#id_case_sensitive').is(":checked") ? request.term : request.term.toLowerCase(),
                     query: true,
+                    case_sensitive: $('#id_case_sensitive').is(":checked"),
                     experimenter_id: WEBCLIENT.active_user,
                     group: WEBCLIENT.active_group_id,
                 },

--- a/omero_mapr/templates/mapr/base_mapr.html
+++ b/omero_mapr/templates/mapr/base_mapr.html
@@ -65,10 +65,10 @@
                 </li>
 
                 <li style="float:right">
-                    <input type="image" class="button mapr_tooltip" src="{% static "webgateway/img/help16.png" %}" data-content="Please start typing to search for {{ mapr_conf.menu_default }}. Autocomplete helps you to enter {{ mapr_conf.menu_default }} ({{ mapr_conf.menu_all }}) by automatically filling information in as you type. 'Match cases' narrows down result by case sensitivity."/>
+                    <input type="image" class="button mapr_tooltip" src="{% static "webgateway/img/help16.png" %}" data-content="Please start typing to search for {{ mapr_conf.menu_default }}. Autocomplete helps you to enter {{ mapr_conf.menu_default }} ({{ mapr_conf.menu_all }}) by automatically filling information in as you type. 'Match case' narrows down result by case sensitivity."/>
                 </li>
                 {% if mapr_conf.case_sensitive %}<li style="float:right">
-                    <div class="case_sensitive mapr_tooltip" data-content="Case sensitive search."><input {% if map_ctx.case_sensitive %}checked{% endif %} id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive"><label for="id_case_sensitive">Match cases</label></div>
+                    <div class="case_sensitive mapr_tooltip" data-content="Case sensitive search."><input {% if map_ctx.case_sensitive %}checked{% endif %} id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive"><label for="id_case_sensitive">Match case</label></div>
                 </li>{% endif %}
 
             </ul>

--- a/omero_mapr/templates/mapr/base_mapr.html
+++ b/omero_mapr/templates/mapr/base_mapr.html
@@ -58,7 +58,7 @@
                 <li class="seperator"></li>
 
                 <li>
-                    <div class="case_sensitive mapr_tooltip" data-content="Case-sensitive search"><input {% if map_ctx.case_sensitive %}checked{% endif %} id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive" hidden><label for="id_case_sensitive">Aa</label></div>
+                    <div class="case_sensitive mapr_tooltip" data-content="Case sensitive search."><input {% if map_ctx.case_sensitive %}checked{% endif %} id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive"><label for="id_case_sensitive">Match cases</label></div>
                 </li>
                 <li>
                     <div class="search filtersearch autocompletesearch" id="autocompletesearch">

--- a/omero_mapr/templates/mapr/base_mapr.html
+++ b/omero_mapr/templates/mapr/base_mapr.html
@@ -58,10 +58,14 @@
                 <li class="seperator"></li>
 
                 <li>
+                    <div class="case_sensitive"><input id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive" hidden><label for="id_case_sensitive">Aa</label></div>
+                </li>
+                <li>
                     <div class="search filtersearch autocompletesearch" id="autocompletesearch">
                         <label for="id_autocomplete">Type {{ menu_default }}...</label>
                         <input type="text" name="id_autocomplete" id="id_autocomplete" title="Search using a {{ menu_default }} ({{ menu_all }}).">
                     </div>
+                    
                 </li>
 
                 <li style="float:right">

--- a/omero_mapr/templates/mapr/base_mapr.html
+++ b/omero_mapr/templates/mapr/base_mapr.html
@@ -58,7 +58,7 @@
                 <li class="seperator"></li>
 
                 <li>
-                    <div class="case_sensitive"><input id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive" hidden><label for="id_case_sensitive">Aa</label></div>
+                    <div class="case_sensitive"><input {% if map_ctx.case_sensitive %}checked{% endif %} id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive" hidden><label for="id_case_sensitive">Aa</label></div>
                 </li>
                 <li>
                     <div class="search filtersearch autocompletesearch" id="autocompletesearch">
@@ -116,7 +116,11 @@
         }
         if (MAPANNOTATIONS.CTX.case_sensitive) {
             payload['case_sensitive'] = MAPANNOTATIONS.CTX.case_sensitive;
+            $('#id_case_sensitive').prop('checked', true);
+        } else {
+            $('#id_case_sensitive').prop('checked', false);
         }
+
         $("#dataTree").data('payload', payload);
 
     </script>

--- a/omero_mapr/templates/mapr/base_mapr.html
+++ b/omero_mapr/templates/mapr/base_mapr.html
@@ -59,16 +59,16 @@
 
                 <li>
                     <div class="search filtersearch autocompletesearch" id="autocompletesearch">
-                        <label for="id_autocomplete">Type {{ mapr_conf.menu_default }}...</label>
-                        <input type="text" name="id_autocomplete" id="id_autocomplete" title="Search using a {{ mapr_conf.menu_default }} ({{ mapr_conf.menu_all }}).">
+                        <label for="id_autocomplete">Type {{ mapr_conf.menu_default|join:', ' }}...</label>
+                        <input type="text" name="id_autocomplete" id="id_autocomplete" title="Search using a {{ mapr_conf.menu_default|join:', ' }} ({{ mapr_conf.menu_all|join:', ' }}).">
                     </div>
                 </li>
 
                 <li style="float:right">
-                    <input type="image" class="button mapr_tooltip" src="{% static "webgateway/img/help16.png" %}" data-content="Please start typing to search for {{ mapr_conf.menu_default }}. Autocomplete helps you to enter {{ mapr_conf.menu_default }} ({{ mapr_conf.menu_all }}) by automatically filling information in as you type. 'Match case' narrows down result by case sensitivity."/>
+                    <input type="image" class="button mapr_tooltip" src="{% static "webgateway/img/help16.png" %}" data-content="{% if mapr_conf.case_sensitive %}Please select 'Match case' or not as desired. {% endif %}Start typing to search for {{ mapr_conf.menu_all|join:' or ' }}. Select the desired item from the dropdown menu which appears after typing has started."/>
                 </li>
                 <li style="float:right;" >
-                    <div class="case_sensitive mapr_tooltip" data-content="Case sensitive search."><input {% if map_ctx.case_sensitive %}checked{% endif %} {% if not mapr_conf.case_sensitive %}disabled{% endif %} id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive"><label for="id_case_sensitive">Match case</label></div>
+                    <div class="case_sensitive"><input {% if map_ctx.case_sensitive %}checked{% endif %} {% if not mapr_conf.case_sensitive %}disabled{% endif %} id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive"><label for="id_case_sensitive">Match case</label></div>
                 </li>
 
             </ul>

--- a/omero_mapr/templates/mapr/base_mapr.html
+++ b/omero_mapr/templates/mapr/base_mapr.html
@@ -58,7 +58,7 @@
                 <li class="seperator"></li>
 
                 <li>
-                    <div class="case_sensitive"><input {% if map_ctx.case_sensitive %}checked{% endif %} id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive" hidden><label for="id_case_sensitive">Aa</label></div>
+                    <div class="case_sensitive mapr_tooltip" data-content="Case-sensitive search"><input {% if map_ctx.case_sensitive %}checked{% endif %} id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive" hidden><label for="id_case_sensitive">Aa</label></div>
                 </li>
                 <li>
                     <div class="search filtersearch autocompletesearch" id="autocompletesearch">
@@ -69,7 +69,7 @@
                 </li>
 
                 <li style="float:right">
-                    <input id="search_hints" type="image" class="button" src="{% static "webgateway/img/help16.png" %}" data-content="Please start typing to search for {{ menu_default }}. Autocomplete will help you to enter {{ menu_default }} ({{ menu_all }}) by automatically filling information in as you type."/>
+                    <input type="image" class="button mapr_tooltip" src="{% static "webgateway/img/help16.png" %}" data-content="Please start typing to search for {{ menu_default }}. Autocomplete will help you to enter {{ menu_default }} ({{ menu_all }}) by automatically filling information in as you type."/>
                 </li>
             </ul>
 

--- a/omero_mapr/templates/mapr/base_mapr.html
+++ b/omero_mapr/templates/mapr/base_mapr.html
@@ -59,17 +59,17 @@
 
                 <li>
                     <div class="search filtersearch autocompletesearch" id="autocompletesearch">
-                        <label for="id_autocomplete">Type {{ menu_default }}...</label>
-                        <input type="text" name="id_autocomplete" id="id_autocomplete" title="Search using a {{ menu_default }} ({{ menu_all }}).">
+                        <label for="id_autocomplete">Type {{ mapr_conf.menu_default }}...</label>
+                        <input type="text" name="id_autocomplete" id="id_autocomplete" title="Search using a {{ mapr_conf.menu_default }} ({{ mapr_conf.menu_all }}).">
                     </div>
                 </li>
 
                 <li style="float:right">
-                    <input type="image" class="button mapr_tooltip" src="{% static "webgateway/img/help16.png" %}" data-content="Please start typing to search for {{ menu_default }}. Autocomplete helps you to enter {{ menu_default }} ({{ menu_all }}) by automatically filling information in as you type. 'Match cases' narrows down result by case sensitivity."/>
+                    <input type="image" class="button mapr_tooltip" src="{% static "webgateway/img/help16.png" %}" data-content="Please start typing to search for {{ mapr_conf.menu_default }}. Autocomplete helps you to enter {{ mapr_conf.menu_default }} ({{ mapr_conf.menu_all }}) by automatically filling information in as you type. 'Match cases' narrows down result by case sensitivity."/>
                 </li>
-                <li style="float:right">
+                {% if mapr_conf.case_sensitive %}<li style="float:right">
                     <div class="case_sensitive mapr_tooltip" data-content="Case sensitive search."><input {% if map_ctx.case_sensitive %}checked{% endif %} id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive"><label for="id_case_sensitive">Match cases</label></div>
-                </li>
+                </li>{% endif %}
 
             </ul>
 

--- a/omero_mapr/templates/mapr/base_mapr.html
+++ b/omero_mapr/templates/mapr/base_mapr.html
@@ -67,9 +67,9 @@
                 <li style="float:right">
                     <input type="image" class="button mapr_tooltip" src="{% static "webgateway/img/help16.png" %}" data-content="Please start typing to search for {{ mapr_conf.menu_default }}. Autocomplete helps you to enter {{ mapr_conf.menu_default }} ({{ mapr_conf.menu_all }}) by automatically filling information in as you type. 'Match case' narrows down result by case sensitivity."/>
                 </li>
-                {% if mapr_conf.case_sensitive %}<li style="float:right">
-                    <div class="case_sensitive mapr_tooltip" data-content="Case sensitive search."><input {% if map_ctx.case_sensitive %}checked{% endif %} id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive"><label for="id_case_sensitive">Match case</label></div>
-                </li>{% endif %}
+                <li style="float:right;" >
+                    <div class="case_sensitive mapr_tooltip" data-content="Case sensitive search."><input {% if map_ctx.case_sensitive %}checked{% endif %} {% if not mapr_conf.case_sensitive %}disabled{% endif %} id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive"><label for="id_case_sensitive">Match case</label></div>
+                </li>
 
             </ul>
 

--- a/omero_mapr/templates/mapr/base_mapr.html
+++ b/omero_mapr/templates/mapr/base_mapr.html
@@ -110,6 +110,9 @@
         if (MAPANNOTATIONS.CTX.query) {
             payload['query'] = MAPANNOTATIONS.CTX.query;
         }
+        if (MAPANNOTATIONS.CTX.case_sensitive) {
+            payload['case_sensitive'] = MAPANNOTATIONS.CTX.case_sensitive;
+        }
         $("#dataTree").data('payload', payload);
 
     </script>

--- a/omero_mapr/templates/mapr/base_mapr.html
+++ b/omero_mapr/templates/mapr/base_mapr.html
@@ -58,19 +58,19 @@
                 <li class="seperator"></li>
 
                 <li>
-                    <div class="case_sensitive mapr_tooltip" data-content="Case sensitive search."><input {% if map_ctx.case_sensitive %}checked{% endif %} id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive"><label for="id_case_sensitive">Match cases</label></div>
-                </li>
-                <li>
                     <div class="search filtersearch autocompletesearch" id="autocompletesearch">
                         <label for="id_autocomplete">Type {{ menu_default }}...</label>
                         <input type="text" name="id_autocomplete" id="id_autocomplete" title="Search using a {{ menu_default }} ({{ menu_all }}).">
                     </div>
-                    
                 </li>
 
                 <li style="float:right">
-                    <input type="image" class="button mapr_tooltip" src="{% static "webgateway/img/help16.png" %}" data-content="Please start typing to search for {{ menu_default }}. Autocomplete will help you to enter {{ menu_default }} ({{ menu_all }}) by automatically filling information in as you type."/>
+                    <input type="image" class="button mapr_tooltip" src="{% static "webgateway/img/help16.png" %}" data-content="Please start typing to search for {{ menu_default }}. Autocomplete helps you to enter {{ menu_default }} ({{ menu_all }}) by automatically filling information in as you type. 'Match cases' narrows down result by case sensitivity."/>
                 </li>
+                <li style="float:right">
+                    <div class="case_sensitive mapr_tooltip" data-content="Case sensitive search."><input {% if map_ctx.case_sensitive %}checked{% endif %} id="id_case_sensitive" type="checkbox" name="case_sensitive" value="Case insensitive"><label for="id_case_sensitive">Match cases</label></div>
+                </li>
+
             </ul>
 
             <div class="clear"></div>

--- a/omero_mapr/testlib/__init__.py
+++ b/omero_mapr/testlib/__init__.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#
+#
+# Copyright (c) 2016 University of Dundee.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author: Aleksandra Tarkowska <A(dot)Tarkowska(at)dundee(dot)ac(dot)uk>.
+#
+# Version: 1.0
+#
+
+from omero.model import ScreenI
+from omero.rtypes import rstring
+from omero.util.temp_files import create_path
+
+from omeroweb.testlib import IWebTest
+
+
+class IMaprTest(IWebTest):
+
+    """
+    Extends ITest
+    """
+
+    def create_csv(
+        self,
+        col_names="Well,Well Type,Concentration",
+        row_data=("A1,Control,0", "A2,Treatment,10")
+    ):
+
+        csv_file_name = create_path("test", ".csv")
+        csv_file = open(csv_file_name, 'w')
+        try:
+            csv_file.write(col_names)
+            csv_file.write("\n")
+            csv_file.write("\n".join(row_data))
+        finally:
+            csv_file.close()
+        return str(csv_file_name)
+
+    def set_name(self, obj, name):
+        q = self.client.sf.getQueryService()
+        up = self.client.sf.getUpdateService()
+        obj = q.get(obj.__class__.__name__, obj.id.val)
+        obj.setName(rstring(name))
+        return up.saveAndReturnObject(obj)
+
+    def create_screen(self, row_count, col_count):
+        # TODO: remove 5.2 vs 5.3 compatibility
+        try:
+            plate = self.importPlates(plateRows=row_count,
+                                      plateCols=col_count)[0]
+        except AttributeError:
+            plate = self.import_plates(plateRows=row_count,
+                                       plateCols=col_count)[0]
+        plate = self.set_name(plate, "Plate001")
+        screen = ScreenI()
+        screen.name = rstring("Screen001")
+        screen.linkPlate(plate.proxy())
+        return (self.client.sf.getUpdateService().saveAndReturnObject(screen),
+                plate)
+
+    def new_screen(self, name=None, description=None):
+        """
+        Creates a new screen object.
+        :param name: The screen name. If None, a UUID string will be used
+        :param description: The screen description
+        """
+        return self.new_object(ScreenI, name=name, description=description)
+
+    def make_screen(self, name=None, description=None, client=None):
+        """
+        Creates a new screen instance and returns the persisted object.
+        :param name: The screen name. If None, a UUID string will be used
+        :param description: The screen description
+        :param client: The client to use to create the object
+        """
+        if client is None:
+            client = self.client
+        screen = self.new_screen(name=name, description=description)
+        return client.sf.getUpdateService().saveAndReturnObject(screen)
+
+    def get_screen_annotations(self):
+        query = """select s from Screen s
+            left outer join fetch s.annotationLinks links
+            left outer join fetch links.child
+            where s.id=%s""" % self.screen.id.val
+        qs = self.client.sf.getQueryService()
+        screen = qs.findByQuery(query, None)
+        anns = screen.linkedAnnotationList()
+        return anns

--- a/omero_mapr/tree.py
+++ b/omero_mapr/tree.py
@@ -153,6 +153,7 @@ def _marshal_map(conn, row):
 
 
 def count_mapannotations(conn, mapann_value, query=False,
+                         case_sensitive=False,
                          mapann_ns=[], mapann_names=[],
                          group_id=-1, experimenter_id=-1):
     ''' Count mapannotiation values
@@ -181,7 +182,8 @@ def count_mapannotations(conn, mapann_value, query=False,
 
     params, where_clause = _set_parameters(
         mapann_ns=mapann_ns, mapann_names=mapann_names,
-        query=query, mapann_value=mapann_value, case_sensitive=False,
+        query=query, mapann_value=mapann_value,
+        case_sensitive=case_sensitive,
         params=None, experimenter_id=experimenter_id,
         page=None, limit=None)
 
@@ -218,6 +220,7 @@ def count_mapannotations(conn, mapann_value, query=False,
 
 
 def marshal_mapannotations(conn, mapann_value, query=False,
+                           case_sensitive=False,
                            mapann_ns=[], mapann_names=[],
                            group_id=-1, experimenter_id=-1,
                            page=1, limit=settings.PAGE):
@@ -253,7 +256,8 @@ def marshal_mapannotations(conn, mapann_value, query=False,
 
     params, where_clause = _set_parameters(
         mapann_ns=mapann_ns, mapann_names=mapann_names,
-        mapann_value=mapann_value, query=query, case_sensitive=False,
+        mapann_value=mapann_value, query=query,
+        case_sensitive=case_sensitive,
         params=None, experimenter_id=experimenter_id,
         page=page, limit=limit)
 

--- a/omero_mapr/tree.py
+++ b/omero_mapr/tree.py
@@ -102,21 +102,16 @@ def _set_parameters(mapann_ns=[], mapann_names=[],
         where_clause.append("a.details.owner.id = :id")
 
     if mapann_value:
+        mapann_value = mapann_value if case_sensitive else mapann_value.lower()
+        _cwc = 'mv.value' if case_sensitive else 'lower(mv.value)'
         if query:
             params.addString(
                 "query",
-                rstring("%%%s%%" % _escape_chars_like(mapann_value.lower())))
-            if case_sensitive:
-                where_clause.append("mv.value like :query")
-            else:
-                where_clause.append("lower(mv.value) like :query")
+                rstring("%%%s%%" % _escape_chars_like(mapann_value)))
+            where_clause.append("%s like :query" % _cwc)
         else:
-            if case_sensitive:
-                params.addString('value', mapann_value)
-                where_clause.append("mv.value  = :value")
-            else:
-                params.addString('value', mapann_value.lower())
-                where_clause.append("lower(mv.value) = :value")
+            params.addString('value', mapann_value)
+            where_clause.append("%s  = :value" % _cwc)
 
     return params, where_clause
 

--- a/omero_mapr/tree.py
+++ b/omero_mapr/tree.py
@@ -51,7 +51,7 @@ def _escape_chars_like(query):
 
 
 def _set_parameters(mapann_ns=[], mapann_names=[],
-                    mapann_value=None, query=False,
+                    mapann_value=None, query=False, case_sensitive=True,
                     params=None, experimenter_id=-1,
                     page=None, limit=settings.PAGE):
 
@@ -108,8 +108,12 @@ def _set_parameters(mapann_ns=[], mapann_names=[],
                 rstring("%%%s%%" % _escape_chars_like(mapann_value.lower())))
             where_clause.append("lower(mv.value) like :query")
         else:
-            params.addString('value', mapann_value)
-            where_clause.append("mv.value  = :value")
+            if case_sensitive:
+                params.addString('value', mapann_value)
+                where_clause.append("mv.value  = :value")
+            else:
+                params.addString('value', mapann_value.lower())
+                where_clause.append("lower(mv.value)  = :value")
 
     return params, where_clause
 
@@ -177,7 +181,7 @@ def count_mapannotations(conn, mapann_value, query=False,
 
     params, where_clause = _set_parameters(
         mapann_ns=mapann_ns, mapann_names=mapann_names,
-        query=query, mapann_value=mapann_value,
+        query=query, mapann_value=mapann_value, case_sensitive=False,
         params=None, experimenter_id=experimenter_id,
         page=None, limit=None)
 
@@ -249,7 +253,7 @@ def marshal_mapannotations(conn, mapann_value, query=False,
 
     params, where_clause = _set_parameters(
         mapann_ns=mapann_ns, mapann_names=mapann_names,
-        mapann_value=mapann_value, query=query,
+        mapann_value=mapann_value, query=query, case_sensitive=False,
         params=None, experimenter_id=experimenter_id,
         page=page, limit=limit)
 

--- a/omero_mapr/views.py
+++ b/omero_mapr/views.py
@@ -565,6 +565,7 @@ def mapannotations_autocomplete(request, menu, conn=None, **kwargs):
         mapann_value = get_unicode_or_default(request, 'value', None)
         query = get_bool_or_default(request, 'query', True)
         mapann_names = get_list_or_default(request, 'name', keys)
+        case_sensitive = get_bool_or_default(request, 'case_sensitive', False)
     except ValueError:
         return HttpResponseBadRequest('Invalid parameter value')
 
@@ -575,6 +576,7 @@ def mapannotations_autocomplete(request, menu, conn=None, **kwargs):
                 conn=conn,
                 mapann_value=mapann_value,
                 query=query,
+                case_sensitive=case_sensitive,
                 mapann_ns=mapann_ns,
                 mapann_names=mapann_names,
                 group_id=group_id,

--- a/omero_mapr/views.py
+++ b/omero_mapr/views.py
@@ -42,6 +42,8 @@ from django.core.exceptions import ValidationError
 
 from django_redis import get_redis_connection
 
+from omero.gateway.utils import toBoolean
+
 from show import mapr_paths_to_object
 from show import MapShow as Show
 import tree as mapr_tree
@@ -133,6 +135,15 @@ def _get_keys(mapr_settings, menu):
     return keys
 
 
+def _get_case_sensitive(mapr_settings, menu):
+    cs = False
+    try:
+        cs = toBoolean(mapr_settings.CONFIG[menu]['case_sensitive'])
+    except:
+        pass
+    return cs
+
+
 def _get_page(request):
     page = get_long_or_default(request, 'page', 1)
     if page < 1:
@@ -161,9 +172,11 @@ def index(request, menu, conn=None, url=None, **kwargs):
     context = _webclient_load_template(request, menu,
                                        conn=conn, url=url, **kwargs)
     context['active_user'] = context['active_user'] or {'id': -1}
-    context['menu_default'] = ", ".join(
-        mapr_settings.CONFIG[menu]['default'])
-    context['menu_all'] = ", ".join(mapr_settings.CONFIG[menu]['all'])
+    context['mapr_conf'] = {
+        'menu': menu,
+        'menu_all': ", ".join(mapr_settings.CONFIG[menu]['all']),
+        'menu_default': ", ".join(mapr_settings.CONFIG[menu]['default']),
+        'case_sensitive': _get_case_sensitive(mapr_settings, menu)}
     context['map_ctx'] = \
         {'label': menu, 'value': value or "", 'query': query or "",
          'case_sensitive': case_sensitive or ""}

--- a/omero_mapr/views.py
+++ b/omero_mapr/views.py
@@ -162,7 +162,11 @@ def index(request, menu, conn=None, url=None, **kwargs):
     try:
         value = get_unicode_or_default(request, 'value', None)
         query = get_bool_or_default(request, 'query', False)
-        case_sensitive = get_bool_or_default(request, 'case_sensitive', False)
+        if _get_case_sensitive(mapr_settings, menu):
+            case_sensitive = get_bool_or_default(
+                request, 'case_sensitive', False)
+        else:
+            case_sensitive = False
     except ValueError:
         logger.error(traceback.format_exc())
         return HttpResponseBadRequest('Invalid parameter value')
@@ -247,7 +251,11 @@ def api_experimenter_list(request, menu, conn=None, **kwargs):
             or get_unicode_or_default(request, 'id', None)
         mapann_names = get_list_or_default(request, 'name', keys)
         query = get_bool_or_default(request, 'query', False)
-        case_sensitive = get_bool_or_default(request, 'case_sensitive', False)
+        if _get_case_sensitive(mapr_settings, menu):
+            case_sensitive = get_bool_or_default(
+                request, 'case_sensitive', False)
+        else:
+            case_sensitive = False
     except ValueError:
         return HttpResponseBadRequest('Invalid parameter value')
 
@@ -306,7 +314,11 @@ def api_mapannotation_list(request, menu, conn=None, **kwargs):
         mapann_value = get_unicode_or_default(request, 'id', None) \
             or get_unicode_or_default(request, 'value', None)
         query = get_bool_or_default(request, 'query', False)
-        case_sensitive = get_bool_or_default(request, 'case_sensitive', False)
+        if _get_case_sensitive(mapr_settings, menu):
+            case_sensitive = get_bool_or_default(
+                request, 'case_sensitive', False)
+        else:
+            case_sensitive = False
         mapann_names = get_list_or_default(request, 'name', keys)
         orphaned = get_bool_or_default(request, 'orphaned', False)
     except ValueError:
@@ -577,7 +589,11 @@ def mapannotations_autocomplete(request, menu, conn=None, **kwargs):
         mapann_value = get_unicode_or_default(request, 'value', None)
         query = get_bool_or_default(request, 'query', True)
         mapann_names = get_list_or_default(request, 'name', keys)
-        case_sensitive = get_bool_or_default(request, 'case_sensitive', False)
+        if _get_case_sensitive(mapr_settings, menu):
+            case_sensitive = get_bool_or_default(
+                request, 'case_sensitive', False)
+        else:
+            case_sensitive = False
     except ValueError:
         return HttpResponseBadRequest('Invalid parameter value')
 

--- a/omero_mapr/views.py
+++ b/omero_mapr/views.py
@@ -151,6 +151,7 @@ def index(request, menu, conn=None, url=None, **kwargs):
     try:
         value = get_unicode_or_default(request, 'value', None)
         query = get_bool_or_default(request, 'query', False)
+        case_sensitive = get_bool_or_default(request, 'case_sensitive', False)
     except ValueError:
         logger.error(traceback.format_exc())
         return HttpResponseBadRequest('Invalid parameter value')
@@ -164,7 +165,8 @@ def index(request, menu, conn=None, url=None, **kwargs):
         mapr_settings.CONFIG[menu]['default'])
     context['menu_all'] = ", ".join(mapr_settings.CONFIG[menu]['all'])
     context['map_ctx'] = \
-        {'label': menu, 'value': value or "", 'query': query or ""}
+        {'label': menu, 'value': value or "", 'query': query or "",
+         'case_sensitive': case_sensitive or ""}
     context['template'] = "mapr/base_mapr.html"
 
     return context
@@ -232,6 +234,7 @@ def api_experimenter_list(request, menu, conn=None, **kwargs):
             or get_unicode_or_default(request, 'id', None)
         mapann_names = get_list_or_default(request, 'name', keys)
         query = get_bool_or_default(request, 'query', False)
+        case_sensitive = get_bool_or_default(request, 'case_sensitive', False)
     except ValueError:
         return HttpResponseBadRequest('Invalid parameter value')
 
@@ -247,15 +250,20 @@ def api_experimenter_list(request, menu, conn=None, **kwargs):
                 mapr_settings.CONFIG[menu]['label'])
 
         if mapann_value is not None:
+            experimenter['extra'] = {}
             if mapann_value:
-                experimenter['extra'] = {'value': mapann_value}
+                experimenter['extra']['value'] = mapann_value
             if query:
-                experimenter['extra'] = {'query': query}
+                experimenter['extra']['query'] = query
+            if case_sensitive:
+                experimenter['extra']['case_sensitive'] = case_sensitive
+
             # count children
             experimenter['childCount'] = mapr_tree.count_mapannotations(
                 conn=conn,
                 mapann_value=mapann_value,
                 query=query,
+                case_sensitive=case_sensitive,
                 mapann_ns=mapann_ns,
                 mapann_names=mapann_names,
                 group_id=group_id,
@@ -286,6 +294,7 @@ def api_mapannotation_list(request, menu, conn=None, **kwargs):
         mapann_value = get_unicode_or_default(request, 'id', None) \
             or get_unicode_or_default(request, 'value', None)
         query = get_bool_or_default(request, 'query', False)
+        case_sensitive = get_bool_or_default(request, 'case_sensitive', False)
         mapann_names = get_list_or_default(request, 'name', keys)
         orphaned = get_bool_or_default(request, 'orphaned', False)
     except ValueError:
@@ -302,6 +311,7 @@ def api_mapannotation_list(request, menu, conn=None, **kwargs):
                 conn=conn,
                 mapann_value=mapann_value,
                 query=query,
+                case_sensitive=case_sensitive,
                 mapann_ns=mapann_ns,
                 mapann_names=mapann_names,
                 group_id=group_id,

--- a/omero_mapr/views.py
+++ b/omero_mapr/views.py
@@ -178,8 +178,8 @@ def index(request, menu, conn=None, url=None, **kwargs):
     context['active_user'] = context['active_user'] or {'id': -1}
     context['mapr_conf'] = {
         'menu': menu,
-        'menu_all': ", ".join(mapr_settings.CONFIG[menu]['all']),
-        'menu_default': ", ".join(mapr_settings.CONFIG[menu]['default']),
+        'menu_all': mapr_settings.CONFIG[menu]['all'],
+        'menu_default': mapr_settings.CONFIG[menu]['default'],
         'case_sensitive': _get_case_sensitive(mapr_settings, menu)}
     context['map_ctx'] = \
         {'label': menu, 'value': value or "", 'query': query or "",

--- a/omero_mapr/views.py
+++ b/omero_mapr/views.py
@@ -263,13 +263,9 @@ def api_experimenter_list(request, menu, conn=None, **kwargs):
                 mapr_settings.CONFIG[menu]['label'])
 
         if mapann_value is not None:
-            experimenter['extra'] = {}
-            if mapann_value:
-                experimenter['extra']['value'] = mapann_value
+            experimenter['extra'] = {'case_sensitive': case_sensitive}
             if query:
                 experimenter['extra']['query'] = query
-            if case_sensitive:
-                experimenter['extra']['case_sensitive'] = case_sensitive
 
             # count children
             experimenter['childCount'] = mapr_tree.count_mapannotations(
@@ -281,6 +277,9 @@ def api_experimenter_list(request, menu, conn=None, **kwargs):
                 mapann_names=mapann_names,
                 group_id=group_id,
                 experimenter_id=experimenter_id)
+
+            if experimenter['childCount'] > 0 and mapann_value:
+                experimenter['extra']['value'] = mapann_value
 
     except ApiUsageException as e:
         return HttpResponseBadRequest(e.serverStackTrace)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def pytest_configure():
                     "default": ["Phenotype"],
                     "all": ["Phenotype", "Phenotype Term Accession"],
                     "ns": ["openmicroscopy.org/omero/bulk_annotations"],
-                    "label": "Phenotype"
+                    "label": "Phenotype",
                 }
             },
             {
@@ -68,7 +68,7 @@ def pytest_configure():
                     "default": ["Organism"],
                     "all": ["Organism"],
                     "ns": ["openmicroscopy.org/omero/bulk_annotations"],
-                    "label": "Organism"
+                    "label": "Organism",
                 }
             },
             {
@@ -77,7 +77,7 @@ def pytest_configure():
                     "default": ["Others"],
                     "all": ["Others"],
                     "ns": ["openmicroscopy.org/omero/bulk_annotations"],
-                    "label": "Others"
+                    "label": "Others",
                 }
             }
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
 import os
 import json
 import django
+import pytest
 
 from django.conf import settings
 from omero_mapr.utils import config_list_to_dict
+
+from omero_mapr.testlib import IMaprTest
 
 # We manually designate which settings we will be using in an environment
 # variable. This is similar to what occurs in the `manage.py`
@@ -54,3 +57,40 @@ def pytest_configure():
         ]
     ))
     django.setup()
+
+
+@pytest.fixture
+def itest(request):
+    """
+    Returns a new L{weblibrary.IMaprTest} instance. With attached
+    finalizer so that pytest will clean it up.
+    """
+    IMaprTest.setup_class()
+
+    def finalizer():
+        IMaprTest.teardown_class()
+    request.addfinalizer(finalizer)
+    return IMaprTest()
+
+
+@pytest.fixture(scope="session")
+def imaprtest(request):
+    """
+    Returns a new L{weblibrary.IMaprTest} instance. With attached
+    finalizer so that pytest will clean it up.
+    """
+    IMaprTest.setup_class()
+
+    def finalizer():
+        IMaprTest.teardown_class()
+    request.addfinalizer(finalizer)
+
+    imt = IMaprTest()
+    csv = os.path.join(
+        os.path.dirname(__file__), 'integration',
+        'bulk_to_map_annotation_context_ns.csv')
+    cfg = os.path.join(
+        os.path.dirname(__file__), 'integration',
+        'bulk_to_map_annotation_context.yml')
+    imt.populate_data(csv, cfg)
+    return imt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#
+#
+# Copyright (c) 2016,2017 University of Dundee.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author: Aleksandra Tarkowska <A(dot)Tarkowska(at)dundee(dot)ac(dot)uk>.
+#
+# Version: 1.0
+#
+
 import os
 import json
 import django
@@ -24,7 +49,8 @@ def pytest_configure():
                     "default": ["Gene Symbol"],
                     "all": ["Gene Symbol", "Gene Identifier"],
                     "ns": ["openmicroscopy.org/omero/bulk_annotations"],
-                    "label": "Gene"
+                    "label": "Gene",
+                    "case_sensitive": True,
                 }
             },
             {
@@ -76,8 +102,9 @@ def itest(request):
 @pytest.fixture(scope="session")
 def imaprtest(request):
     """
-    Returns a new L{weblibrary.IMaprTest} instance. With attached
-    finalizer so that pytest will clean it up.
+    Returns a new L{weblibrary.IMaprTest} instance and
+    populate metadata. Attached finalizer so that pytest
+    will clean it up.
     """
     IMaprTest.setup_class()
 

--- a/tests/integration/bulk_to_map_annotation_context_ns.csv
+++ b/tests/integration/bulk_to_map_annotation_context_ns.csv
@@ -1,5 +1,7 @@
 Plate,Well Number,Well,Gene Identifier,Gene Symbol,Organism
-Plate001,1,A1,CDC20,ENSG00000117399,Homo sapiens
-Plate001,2,A2,CDC20,YGL116W,Mouse
-Plate001,3,A3,beta'Cop,apostrophe,Human
-Plate001,4,A4,percent,123 (abc%def),Some organism
+Plate001,1,A1,cdc14,CG7134,Homo sapiens
+Plate001,1,A2,cdc14,FBgn0031952,Homo sapiens
+Plate001,2,A3,CDC14,YFR028C,Mouse
+Plate001,2,A4,Cdc14,YFR028C,Mouse
+Plate001,3,A5,beta'Cop,apostrophe,Human
+Plate001,4,A6,percent,123 (abc%def),Some organism

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -1,3 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#
+#
+# Copyright (c) 2016,2017 University of Dundee.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author: Aleksandra Tarkowska <A(dot)Tarkowska(at)dundee(dot)ac(dot)uk>.
+#
+# Version: 1.0
+#
+
 import pytest
 
 from django.core.urlresolvers import reverse, NoReverseMatch

--- a/tests/integration/test_mapr.py
+++ b/tests/integration/test_mapr.py
@@ -144,7 +144,10 @@ class TestMapr(IMaprTest):
         ctx.write_to_omero()
 
     @pytest.mark.parametrize('ac', (
-        {'menu': 'gene', 'value': 'CDC20', 'search_value': 'cdc'},
+        {'menu': 'gene', 'value': 'CDC20',
+         'search_value': 'cdc', 'case_sensitive': False},
+        {'menu': 'gene', 'value': 'CDC20',
+         'search_value': 'CDC', 'case_sensitive': True},
         {'menu': 'organism', 'value': 'Homo sapiens', 'search_value': 'homo'},
         {'menu': 'gene', 'value': "beta'Cop", 'search_value': "'"},
         {'menu': 'gene', 'value': "123 (abc%def)", 'search_value': "%"},
@@ -153,8 +156,13 @@ class TestMapr(IMaprTest):
         # test autocomplete
         request_url = reverse("mapannotations_autocomplete",
                               args=[ac['menu']])
+        try:
+            _cs = ac['case_sensitive']
+        except KeyError:
+            _cs = False
         data = {
             'value': ac['search_value'],
+            'case_sensitive': _cs,
             'query': 'true',
         }
         response = _get_response_json(self.django_client, request_url, data)

--- a/tests/integration/test_mapr_autocomplete.py
+++ b/tests/integration/test_mapr_autocomplete.py
@@ -3,7 +3,7 @@
 #
 #
 #
-# Copyright (c) 2016 University of Dundee.
+# Copyright (c) 2016,2017 University of Dundee.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/integration/test_mapr_autocomplete.py
+++ b/tests/integration/test_mapr_autocomplete.py
@@ -29,91 +29,15 @@ import pytest
 from django.core.urlresolvers import reverse
 
 from omero.constants.namespaces import NSBULKANNOTATIONS
-from omero.model import ScreenI
-from omero.rtypes import rstring, unwrap
-from omero.util.temp_files import create_path
+from omero.rtypes import unwrap
 from omero.util.populate_metadata import BulkToMapAnnotationContext
 from omero.util.populate_metadata import ParsingContext
 
-from omeroweb.testlib import IWebTest, _get_response_json
+from omero_mapr.testlib import IMaprTest
+from omeroweb.testlib import _get_response_json
 
 
-class IMaprTest(IWebTest):
-
-    """
-    Extends ITest
-    """
-
-    def create_csv(
-        self,
-        col_names="Well,Well Type,Concentration",
-        row_data=("A1,Control,0", "A2,Treatment,10")
-    ):
-
-        csv_file_name = create_path("test", ".csv")
-        csv_file = open(csv_file_name, 'w')
-        try:
-            csv_file.write(col_names)
-            csv_file.write("\n")
-            csv_file.write("\n".join(row_data))
-        finally:
-            csv_file.close()
-        return str(csv_file_name)
-
-    def set_name(self, obj, name):
-        q = self.client.sf.getQueryService()
-        up = self.client.sf.getUpdateService()
-        obj = q.get(obj.__class__.__name__, obj.id.val)
-        obj.setName(rstring(name))
-        return up.saveAndReturnObject(obj)
-
-    def create_screen(self, row_count, col_count):
-        # TODO: remove 5.2 vs 5.3 compatibility
-        try:
-            plate = self.importPlates(plateRows=row_count,
-                                      plateCols=col_count)[0]
-        except AttributeError:
-            plate = self.import_plates(plateRows=row_count,
-                                       plateCols=col_count)[0]
-        plate = self.set_name(plate, "Plate001")
-        screen = ScreenI()
-        screen.name = rstring("Screen001")
-        screen.linkPlate(plate.proxy())
-        return (self.client.sf.getUpdateService().saveAndReturnObject(screen),
-                plate)
-
-    def new_screen(self, name=None, description=None):
-        """
-        Creates a new screen object.
-        :param name: The screen name. If None, a UUID string will be used
-        :param description: The screen description
-        """
-        return self.new_object(ScreenI, name=name, description=description)
-
-    def make_screen(self, name=None, description=None, client=None):
-        """
-        Creates a new screen instance and returns the persisted object.
-        :param name: The screen name. If None, a UUID string will be used
-        :param description: The screen description
-        :param client: The client to use to create the object
-        """
-        if client is None:
-            client = self.client
-        screen = self.new_screen(name=name, description=description)
-        return client.sf.getUpdateService().saveAndReturnObject(screen)
-
-    def get_screen_annotations(self):
-        query = """select s from Screen s
-            left outer join fetch s.annotationLinks links
-            left outer join fetch links.child
-            where s.id=%s""" % self.screen.id.val
-        qs = self.client.sf.getQueryService()
-        screen = qs.findByQuery(query, None)
-        anns = screen.linkedAnnotationList()
-        return anns
-
-
-class TestMapr(IMaprTest):
+class TestMaprAutocomplete(IMaprTest):
 
     def setup_method(self, method):
         row_count = 1
@@ -149,7 +73,7 @@ class TestMapr(IMaprTest):
         {'menu': 'gene', 'value': "beta'Cop", 'search_value': "'"},
         {'menu': 'gene', 'value': "123 (abc%def)", 'search_value': "%"},
     ))
-    def test_autocomplete(self, ac):
+    def test_autocomplete_default(self, ac):
         # test autocomplete
         request_url = reverse("mapannotations_autocomplete",
                               args=[ac['menu']])
@@ -176,13 +100,9 @@ class TestMapr(IMaprTest):
         # test autocomplete
         request_url = reverse("mapannotations_autocomplete",
                               args=[ac['menu']])
-        try:
-            _cs = ac['case_sensitive']
-        except KeyError:
-            _cs = False
         data = {
             'value': ac['search_value'],
-            'case_sensitive': _cs,
+            'case_sensitive': ac['case_sensitive'],
             'query': 'true',
         }
         response = _get_response_json(self.django_client, request_url, data)
@@ -197,13 +117,9 @@ class TestMapr(IMaprTest):
         # test autocomplete
         request_url = reverse("mapannotations_autocomplete",
                               args=[ac['menu']])
-        try:
-            _cs = ac['case_sensitive']
-        except KeyError:
-            _cs = False
         data = {
             'value': ac['search_value'],
-            'case_sensitive': _cs,
+            'case_sensitive': ac['case_sensitive'],
             'query': 'true',
         }
         response = _get_response_json(self.django_client, request_url, data)

--- a/tests/integration/test_mapr_views.py
+++ b/tests/integration/test_mapr_views.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#
+#
+# Copyright (c) 2016 University of Dundee.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author: Aleksandra Tarkowska <A(dot)Tarkowska(at)dundee(dot)ac(dot)uk>.
+#
+# Version: 1.0
+#
+
+import json
+import pytest
+
+from django.core.urlresolvers import reverse
+
+from omeroweb.testlib import _get_response_json
+
+
+class TestMaprViews(object):
+
+    @pytest.mark.parametrize('ac', (
+        {'menu': 'organism', 'value': 'Homo sapiens',
+         'res_value': {'value': 'Homo sapiens'}, 'count': 1},
+        {'menu': 'organism', 'value': "value_doesn't_exist",
+         'res_value': {}, 'count': 0},
+        {'menu': 'gene', 'value': "cdc14",
+         'res_value': {'value': 'cdc14'}, 'count': 3},
+
+        # case sensitive
+        # key doesnt exists, case sensitive
+        {'menu': 'gene', 'value': 'CDC20', 'case_sensitive': True,
+         'res_value': {}, 'count': 0},
+        # key doesnt exists, case insensitive
+        {'menu': 'gene', 'value': 'CDC20', 'case_sensitive': False,
+         'res_value': {}, 'count': 0},
+
+        # find matching key, case sensitive
+        {'menu': 'gene', 'value': 'Cdc14', 'case_sensitive': True,
+         'res_value': {'value': 'Cdc14'}, 'count': 1},
+        # find matching key, case insensitive
+        {'menu': 'gene', 'value': 'cDc14', 'case_sensitive': False,
+         'res_value': {'value': 'cDc14'}, 'count': 3},
+    ))
+    def test_api_experimenter_list(self, imaprtest, ac):
+        def _expected(menu, extra, count, uid):
+            _res = {
+                "experimenter": {
+                    "omeName": menu.capitalize(),
+                    "firstName": menu.capitalize(),
+                    "extra": extra,
+                    "lastName": "",
+                    "id": uid,
+                    "childCount": count,
+                }
+            }
+            _res['experimenter']['extra'] = extra if extra else {}
+            return json.loads(json.dumps(_res))
+
+        request_url = reverse("mapannotations_api_experimenters",
+                              args=[ac['menu']])
+        data = {
+            'value': ac['value'],
+            # 'experimenter_id': -1 by default
+        }
+        try:
+            cs = ac['case_sensitive']
+        except KeyError:
+            cs = False
+        data['case_sensitive'] = cs
+        ac['res_value']['case_sensitive'] = cs
+        response = _get_response_json(
+            imaprtest.django_client, request_url, data)
+
+        assert response == _expected(
+            ac['menu'], ac['res_value'], ac['count'], -1)
+
+    @pytest.mark.parametrize('ac', (
+        {'menu': 'organism', 'value': 'Homo sapiens',
+         'res_value': {'Homo sapiens': 2}},
+        {'menu': 'organism', 'value': "value_doesn't_exist",
+         'res_value': {}},
+        {'menu': 'gene', 'value': "cdc14",
+         'res_value': {'CDC14': 1, 'cdc14': 2, 'Cdc14': 1}},
+
+        # case sensitive
+        # key doesnt exists, case sensitive
+        {'menu': 'gene', 'value': "value_doesn't_exist",
+         'case_sensitive': True, 'res_value': {}},
+        # key doesnt exists, case insensitive
+        {'menu': 'gene', 'value': "value_doesn't_exist",
+         'case_sensitive': False, 'res_value': {}},
+
+        # find matching key, case sensitive
+        {'menu': 'gene', 'value': 'Cdc14', 'case_sensitive': True,
+         'res_value': {'Cdc14': 1}},
+        # find matching key, case insensitive
+        {'menu': 'gene', 'value': 'cDc14', 'case_sensitive': False,
+         'res_value': {'CDC14': 1, 'cdc14': 2, 'Cdc14': 1}, 'count': 3},
+    ))
+    def test_api_mapannotations(self, imaprtest, ac):
+        request_url = reverse("mapannotations_api_mapannotations",
+                              args=[ac['menu']])
+        data = {
+            'value': ac['value'],
+            'orphaned': True,
+            # 'experimenter_id': -1 by default
+        }
+        try:
+            data['case_sensitive'] = ac['case_sensitive']
+        except KeyError:
+            pass
+
+        response = _get_response_json(
+            imaprtest.django_client, request_url, data)
+
+        try:
+            c = ac['count']
+        except KeyError:
+            c = len(ac['res_value'])
+        assert len(response['maps']) == c
+
+        if len(ac['res_value']) > 0:
+            names = ["%s (%d)" % (k, v) for k, v in ac['res_value'].items()]
+            for r in response['maps']:
+                assert r['name'] in names

--- a/tests/integration/test_mapr_views.py
+++ b/tests/integration/test_mapr_views.py
@@ -3,7 +3,7 @@
 #
 #
 #
-# Copyright (c) 2016 University of Dundee.
+# Copyright (c) 2016,2017 University of Dundee.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as


### PR DESCRIPTION
This PR relaxe queries to load case insensitive data https://trello.com/c/M3q00BhI/55-mapr-case-insensitive-searching
<img width="408" alt="google chromescreensnapz003" src="https://cloud.githubusercontent.com/assets/1065155/23324426/9e23d374-fae5-11e6-82f0-3a5ea5fa92f7.png">


Test:

- **Case sensitive is only enabled in gene and compound tab** (configurable)
- Check:
  - mapr/gene/?value=cdc14
  - mapr/gene/?value=cdc14&case_sensitive=true
  - mapr/gene/?value=cdc14&case_sensitive=true&query=true
 **`case_sensitive` & `query` are not mutually exclusive**
- type `cdc14` in autocomplete and test `Match case`
- check if tests passes https://idr-ci.openmicroscopy.org:8443/job/MAPR-test/
- check help tooltip in `?` button
