### PR TITLE
Add more info and example config to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ MAPR
 OMERO.mapr is an OMERO.web app that enables browsing of data through attributes linked to images
 in the form of Map Annotations.
 
-It is used extensively by the `Image Data Resource <http://idr.openmicroscopy.org/>`_,
+It is used extensively by the `Image Data Resource <https://idr.openmicroscopy.org/>`_,
 allowing users to find data by various categories such as Genes, Phenotypes, Organism etc.
 
 In OMERO, Map Annotations are lists of named attributes that can be used to

--- a/README.rst
+++ b/README.rst
@@ -71,9 +71,9 @@ add a map annotation corresponding to the configuration above:
 
 ::
 
-    key_value_data = [["Gene Identifier","CG7134"],
-                      ["Gene Identifier URL", "http://www.flybase.org/cgi-bin/uniq.html?field=SYN&db=fbgn&context=CG7134"],
-                      ["Gene Symbol","cdc14"]]
+    key_value_data = [["Gene Identifier","ENSG00000117399"],
+                      ["Gene Identifier URL", "http://www.ensembl.org/id/ENSG00000117399"],
+                      ["Gene Symbol","CDC20"]]
     map_ann = omero.gateway.MapAnnotationWrapper(conn)
     map_ann.setValue(key_value_data)
     map_ann.setNs("openmicroscopy.org/mapr/gene")
@@ -83,7 +83,11 @@ add a map annotation corresponding to the configuration above:
 
 
 Now restart OMERO.web as normal for the configuration above to take effect.
-You should now be able to browse to a ``Genes`` page and search for ``cdc14``.
+You should now be able to browse to a ``Genes`` page and search for
+``CDC20`` or ``ENSG00000117399``.
+
+.. image:: https://user-images.githubusercontent.com/900055/36256919-d8a19fb6-124c-11e8-8628-d792ff29bd22.png
+
 
 Testing
 =======

--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,12 @@ And to search for "siRNAi" targets we can add:
     $ bin/omero config append omero.web.mapr.config '{"menu": "sirnai", "config":{"default":["siRNAi"], "all":["siRNAi"], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"siRNAi"}}'
 
 After configuring appropriate ``top_links`` for each of these and restarting web, we
-can now search for Antibodies or siRNAi Key-Value pairs added by users
+can now search for Antibodies or siRNAi Key-Value pairs added by users:
+
+
+.. image:: https://user-images.githubusercontent.com/900055/36311352-f11be692-1322-11e8-990b-076e1e208f86.png
+
+.. image:: https://user-images.githubusercontent.com/900055/36311363-f3ce8660-1322-11e8-92a5-a79b842eb133.png
 
 Testing
 =======

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,9 @@ by specified keys will be searchable. For example,
 ``Gene Symbol`` and ``Gene Identifier``.
 
 
+.. image:: https://user-images.githubusercontent.com/900055/36256919-d8a19fb6-124c-11e8-8628-d792ff29bd22.png
+
+
 Requirements
 ============
 
@@ -48,6 +51,9 @@ Add the app to the list of installed apps:
     $ bin/omero config append omero.web.apps '"omero_mapr"'
 
 
+Config Settings
+===============
+
 Configure the categories that we want to search for. In this example we want to search
 for Map Annotations of namespace ``openmicroscopy.org/mapr/gene`` searching for
 attributes under the ``Gene Symbol`` and ``Gene Identifier`` keys.
@@ -66,7 +72,8 @@ In this example a link of ``Genes`` with tooltip ``Find Gene annotations`` will 
 
 
 Finally, we can add a map annotation to an Image that is in a Screen -> Plate -> Well
-hierarchy. This uses the OMERO `Python API <https://docs.openmicroscopy.org/latest/omero/developers/Python.html>`_ to
+or Project -> Dataset -> Image hierarchy.
+This code uses the OMERO `Python API <https://docs.openmicroscopy.org/latest/omero/developers/Python.html>`_ to
 add a map annotation corresponding to the configuration above:
 
 ::
@@ -86,8 +93,27 @@ Now restart OMERO.web as normal for the configuration above to take effect.
 You should now be able to browse to a ``Genes`` page and search for
 ``CDC20`` or ``ENSG00000117399``.
 
-.. image:: https://user-images.githubusercontent.com/900055/36256919-d8a19fb6-124c-11e8-8628-d792ff29bd22.png
 
+User-edited Map Annotations
+===========================
+
+Map Annotations that are added using the webclient or Insight in the Key-Value panel
+use a specific "client" namespace. We can therefore configure OMERO.mapr to search
+for these annotations using the namespace ``openmicroscopy.org/omero/client/mapAnnotation``.
+For example, to search for "Primary Antibody" or "Secondary Antibody" values, we can add:
+
+::
+
+    $ bin/omero config append omero.web.mapr.config '{"menu": "antibody", "config":{"default":["Primary Antibody"], "all":["Primary Antibody", "Secondary Antibody"], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"Antibody"}}'
+
+And to search for "siRNAi" targets we can add:
+
+::
+
+    $ bin/omero config append omero.web.mapr.config '{"menu": "sirnai", "config":{"default":["siRNAi"], "all":["siRNAi"], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"siRNAi"}}'
+
+After configuring appropriate ``top_links`` for each of these and restarting web, we
+can now search for Antibodies or siRNAi Key-Value pairs added by users
 
 Testing
 =======

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
 MAPR
 ====
 
-OMERO.map is an OMERO.web app that enables browsing of data through attributes linked to images
+OMERO.mapr is an OMERO.web app that enables browsing of data through attributes linked to images
 in the form of Map Annotations.
 
 It is used extensively by the `Image Data Resource <http://idr.openmicroscopy.org/>`_,


### PR DESCRIPTION
See https://trello.com/c/2bBx96kX/23-mapr-installation

Make the install docs more user-friendly with some background info and example how to set-up Map Annotations to work with a given config.

Staged at https://github.com/will-moore/omero-mapr/tree/README_more_info

TODO: I'll also look at using ```mapr``` to search for client-created Map Annotations as suggested elsewhere...