### PR TITLE
Cap django-redis prior to 4.9.0

### DIFF
--- a/omero_mapr/__init__.py
+++ b/omero_mapr/__init__.py
@@ -26,7 +26,7 @@
 from omero_mapr.utils.version import get_version
 
 
-VERSION = (0, 2, 0)
+VERSION = (0, 2, 1)
 
 __version__ = get_version(VERSION)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-django-redis>4.4
+django-redis>4.4,<4.9


### PR DESCRIPTION
The 4.9.0 release of django-redis drops support for versions of Django below 1.11.

See also https://github.com/openmicroscopy/openmicroscopy/pull/5674.

As the version of `omero-mapr` currently break the https://github.com/openmicroscopy/ansible-role-omero-web-apps role in https://github.com/IDR/deployment, propose to cut the `0.2.1` release of `omero-mapr 0.2.1` and bump in IDR - see  https://github.com/ome/omero-mapr/milestone/16 and https://github.com/ome/omero-mapr/milestone/17.