### PR TITLE
Remove setup_requires declaration from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setup(
     url="https://github.com/ome/omero-mapr",
     download_url='https://github.com/ome/omero-mapr/tarball/%s' % version,  # NOQA
     install_requires=install_requires,
-    setup_requires=['pytest-runner==3.0.1'],
     tests_require=tests_require,
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
The pytest-runner is already declared in requirements-test.txt. This change should fix the installation of omero-mapr on old Python/pip (e.g. CentOS) following the PyPI TLS v1.0/1.1 deprecation

See also https://github.com/openmicroscopy/omero-marshal/pull/50

To test this PR,
- check Travis remains green
- test

```
$ docker run --rm -it centos:centos7
[root@985cea0418f9 /]# yum install -y python-virtualenv && virtualenv /tmp/venv
[root@985cea0418f9 /]# /tmp/venv/bin/pip install omero-mapr # should fail
[root@985cea0418f9 /]# /tmp/venv/bin/pip install https://github.com/sbesson/omero-mapr/archive/pypi_tls_1.0.zip # should work
```