### PR TITLE
filtersearch css fix

### DIFF
--- a/omero_mapr/static/mapr/css/ome.mapr.css
+++ b/omero_mapr/static/mapr/css/ome.mapr.css
@@ -28,6 +28,11 @@ ul.ui-autocomplete{
     width: 135px;
 }
 
+#autocompletesearch {
+    /* override .filtersearch width from webclient */
+    width: 180px;
+}
+
 .autocompletesearch label{
     top: 5px;
 }


### PR DESCRIPTION
Fixes style broken in
https://github.com/openmicroscopy/openmicroscopy/pull/5669

Before and after this fix:

<img width="302" alt="screen shot 2018-04-19 at 16 23 44" src="https://user-images.githubusercontent.com/900055/39001377-19c27998-43ee-11e8-8738-b8772989cbd6.png">

<img width="340" alt="screen shot 2018-04-19 at 16 23 30" src="https://user-images.githubusercontent.com/900055/39001381-1c2ea774-43ee-11e8-8916-d5a50c42e197.png">

In general we should try not to reuse css from webclient in different components in other apps, since this is quite fragile. However, it's tricky to know what is likely to break and we don't want to duplicate all of webclient css!