### PR TITLE
Add AnyValue config to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,16 +14,19 @@ in the form of Map Annotations.
 It is used extensively by the `Image Data Resource <https://idr.openmicroscopy.org/>`_,
 allowing users to find data by various categories such as Genes, Phenotypes, Organism etc.
 
-In OMERO, Map Annotations are lists of named attributes that can be used to
+In OMERO, Map Annotations are lists of named attributes or "Key-Value Pairs" that can be used to
 annotate many types of data. Annotations can be assigned a ``namespace``
 to indicate the origin and purpose of the annotation.
 
-In OMERO.mapr we can configure different categories of attributes using
-different namespaces, such as ``openmicroscopy.org/mapr/gene``.
-Within Map Annotations with this namespace, attributes named
-by specified keys will be searchable. For example,
-``Gene Symbol`` and ``Gene Identifier``.
+Map Annotations created by users via the Insight client or webclient all have the
+namespace ``openmicroscopy.org/omero/client/mapAnnotation``, whereas other
+Map Annotations created via the OMERO API by other tools should have a distinct
+namespace.
 
+We can configure OMERO.mapr to search for Map Annotations of specified ``namespace``,
+looking for ``Values`` under specifed ``Keys``.
+For example, seach for values under key ``Gene Symbol`` or ``Gene Identifier``
+and namespace ``openmicroscopy.org/mapr/gene``.
 
 .. image:: https://user-images.githubusercontent.com/900055/36256919-d8a19fb6-124c-11e8-8628-d792ff29bd22.png
 
@@ -37,6 +40,8 @@ Installing from Pypi
 ====================
 
 This section assumes that an OMERO.web is already installed.
+NB: Configuration of the settings (see below) is not optional
+and is required for the app to work.
 
 Install the app using `pip <https://pip.pypa.io/en/stable/>`_:
 
@@ -54,7 +59,51 @@ Add the app to the list of installed apps:
 Config Settings
 ===============
 
-Configure the categories that we want to search for. In this example we want to search
+You need to configure the namespaces and keys that you want users to be able to search for.
+
+User-edited Map Annotations
+---------------------------
+
+Map Annotations that are added using the webclient or Insight in the Key-Value panel
+use a specific "client" namespace. We can therefore configure OMERO.mapr to search
+for these annotations using the namespace ``openmicroscopy.org/omero/client/mapAnnotation``.
+For example, to search for "Primary Antibody" or "Secondary Antibody" values, we can add:
+
+::
+
+    $ bin/omero config append omero.web.mapr.config '{"menu": "antibody", "config":{"default":["Primary Antibody"], "all":["Primary Antibody", "Secondary Antibody"], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"Antibody"}}'
+
+We can add an "Antibodies" link with to the top of the webclient page to take us to the Antibodies search page.
+The link tooltip is "Find Antibody values".
+The ``viewname`` should be in the form ``maprindex_{menu}`` where ``{menu}`` is the the ``menu`` value in the previous config.
+
+::
+
+    $ bin/omero config append omero.web.ui.top_links '["Antibodies", {"viewname": "maprindex_antibody"}, {"title": "Find Antibody values"}]'
+
+After restarting web, we can now search for Antibodies:
+
+.. image:: https://user-images.githubusercontent.com/900055/40605069-063ff29a-6259-11e8-9295-3887dde0441f.png
+
+
+We can also specify an empty list of keys to search for *any* value.
+
+::
+
+    $ bin/omero config append omero.web.mapr.config '{"menu": "anyvalue", "config":{"default":["Any Value"], "all":[], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"Any"}}'
+
+    # Top link
+    omero config append omero.web.ui.top_links '["Any Value", {"viewname": "maprindex_anyvalue"}, {"title": "Find Any Value"}]'
+
+After restarting web, we can now search for any Value, such as "INCENP":
+
+.. image:: https://user-images.githubusercontent.com/900055/40605101-1cd1925c-6259-11e8-93a8-e72af2e570d3.png
+
+
+Other Map Annotations
+---------------------
+
+In this example we want to search
 for Map Annotations of namespace ``openmicroscopy.org/mapr/gene`` searching for
 attributes under the ``Gene Symbol`` and ``Gene Identifier`` keys.
 
@@ -62,9 +111,7 @@ attributes under the ``Gene Symbol`` and ``Gene Identifier`` keys.
 
     $ bin/omero config append omero.web.mapr.config '{"menu": "gene","config": {"default": ["Gene Symbol"],"all": ["Gene Symbol", "Gene Identifier"],"ns": ["openmicroscopy.org/mapr/gene"],"label": "Gene"}}'
 
-We can add a link to the top of the webclient page to take us to the mapr Genes search page.
-The ``viewname`` should be in the form ``maprindex_{menu}`` where ``{menu}`` is the the ``menu`` value in the previous config.
-In this example a link of ``Genes`` with tooltip ``Find Gene annotations`` will take us to the ``gene`` search page. The ``query_string`` parameters are added to the URL, with ``"experimenter": -1``
+Now add a top link of ``Genes`` with tooltip ``Find Gene annotations`` that will take us to the ``gene`` search page. The ``query_string`` parameters are added to the URL, with ``"experimenter": -1``
 specifying that we want to search across all users.
 
 ::
@@ -93,40 +140,6 @@ add a map annotation corresponding to the configuration above:
 Now restart OMERO.web as normal for the configuration above to take effect.
 You should now be able to browse to a ``Genes`` page and search for
 ``CDC20`` or ``ENSG00000117399``.
-
-
-User-edited Map Annotations
-===========================
-
-Map Annotations that are added using the webclient or Insight in the Key-Value panel
-use a specific "client" namespace. We can therefore configure OMERO.mapr to search
-for these annotations using the namespace ``openmicroscopy.org/omero/client/mapAnnotation``.
-For example, to search for "Primary Antibody" or "Secondary Antibody" values, we can add:
-
-::
-
-    $ bin/omero config append omero.web.mapr.config '{"menu": "antibody", "config":{"default":["Primary Antibody"], "all":["Primary Antibody", "Secondary Antibody"], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"Antibody"}}'
-
-    # Top link (without experimenter: -1)
-    $ bin/omero config append omero.web.ui.top_links '["Antibodies", {"viewname": "maprindex_antibody"}, {"title": "Find Antibody values"}]'
-
-After restarting web, we can now search for Antibodies:
-
-.. image:: https://user-images.githubusercontent.com/900055/40605069-063ff29a-6259-11e8-9295-3887dde0441f.png
-
-
-We can also specify an empty list of keys to search for *any* value.
-
-::
-
-    $ bin/omero config append omero.web.mapr.config '{"menu": "anyvalue", "config":{"default":["Any Value"], "all":[], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"Any"}}'
-
-    # Top link
-    omero config append omero.web.ui.top_links '["Any Value", {"viewname": "maprindex_anyvalue"}, {"title": "Find Any Value"}]'
-
-After restarting web, we can now search for any Value, such as "INCENP":
-
-.. image:: https://user-images.githubusercontent.com/900055/40605101-1cd1925c-6259-11e8-93a8-e72af2e570d3.png
 
 
 Testing

--- a/README.rst
+++ b/README.rst
@@ -106,14 +106,14 @@ For example, to search for "Primary Antibody" or "Secondary Antibody" values, we
 
     $ bin/omero config append omero.web.mapr.config '{"menu": "antibody", "config":{"default":["Primary Antibody"], "all":["Primary Antibody", "Secondary Antibody"], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"Antibody"}}'
 
-And to search for "siRNAi" targets we can add:
+We can also specify an empty list of keys to search for *any* value.
 
 ::
 
-    $ bin/omero config append omero.web.mapr.config '{"menu": "sirnai", "config":{"default":["siRNAi"], "all":["siRNAi"], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"siRNAi"}}'
+    $ bin/omero config append omero.web.mapr.config '{"menu": "anyvalue", "config":{"default":["Any Value"], "all":[], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"Any"}}'
 
 After configuring appropriate ``top_links`` for each of these and restarting web, we
-can now search for Antibodies or siRNAi Key-Value pairs added by users:
+can now search for Antibodies or *all* Values in Key-Value pairs added by users:
 
 
 .. image:: https://user-images.githubusercontent.com/900055/36311352-f11be692-1322-11e8-990b-076e1e208f86.png

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ to indicate the origin and purpose of the annotation.
 
 Map Annotations created by users via the Insight client or webclient all have the
 namespace ``openmicroscopy.org/omero/client/mapAnnotation``, whereas other
-Map Annotations created via the OMERO API by other tools should have a distinct
+Map Annotations created via the OMERO API by other tools should have their own distinct
 namespace.
 
 We can configure OMERO.mapr to search for Map Annotations of specified ``namespace``,
@@ -73,7 +73,7 @@ For example, to search for "Primary Antibody" or "Secondary Antibody" values, we
 
     $ bin/omero config append omero.web.mapr.config '{"menu": "antibody", "config":{"default":["Primary Antibody"], "all":["Primary Antibody", "Secondary Antibody"], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"Antibody"}}'
 
-We can add an "Antibodies" link with to the top of the webclient page to take us to the Antibodies search page.
+We can add an "Antibodies" link to the top of the webclient page to take us to the Antibodies search page.
 The link tooltip is "Find Antibody values".
 The ``viewname`` should be in the form ``maprindex_{menu}`` where ``{menu}`` is the the ``menu`` value in the previous config.
 
@@ -93,7 +93,7 @@ We can also specify an empty list of keys to search for *any* value.
     $ bin/omero config append omero.web.mapr.config '{"menu": "anyvalue", "config":{"default":["Any Value"], "all":[], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"Any"}}'
 
     # Top link
-    omero config append omero.web.ui.top_links '["Any Value", {"viewname": "maprindex_anyvalue"}, {"title": "Find Any Value"}]'
+    $ bin/omero config append omero.web.ui.top_links '["Any Value", {"viewname": "maprindex_anyvalue"}, {"title": "Find Any Value"}]'
 
 After restarting web, we can now search for any Value, such as "INCENP":
 
@@ -133,8 +133,8 @@ add a map annotation corresponding to the configuration above:
     map_ann.setValue(key_value_data)
     map_ann.setNs("openmicroscopy.org/mapr/gene")
     map_ann.save()
-    i = conn.getObject('Image', 2917)
-    i.linkAnnotation(map_ann)
+    image = conn.getObject('Image', 2917)
+    image.linkAnnotation(map_ann)
 
 
 Now restart OMERO.web as normal for the configuration above to take effect.

--- a/README.rst
+++ b/README.rst
@@ -116,9 +116,10 @@ After configuring appropriate ``top_links`` for each of these and restarting web
 can now search for Antibodies or *all* Values in Key-Value pairs added by users:
 
 
-.. image:: https://user-images.githubusercontent.com/900055/36311352-f11be692-1322-11e8-990b-076e1e208f86.png
+.. image:: https://user-images.githubusercontent.com/900055/40605069-063ff29a-6259-11e8-9295-3887dde0441f.png
 
-.. image:: https://user-images.githubusercontent.com/900055/36311363-f3ce8660-1322-11e8-92a5-a79b842eb133.png
+.. image:: https://user-images.githubusercontent.com/900055/40605101-1cd1925c-6259-11e8-93a8-e72af2e570d3.png
+
 
 Testing
 =======

--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,11 @@ For example, to search for "Primary Antibody" or "Secondary Antibody" values, we
     # Top link (without experimenter: -1)
     $ bin/omero config append omero.web.ui.top_links '["Antibodies", {"viewname": "maprindex_antibody"}, {"title": "Find Antibody values"}]'
 
+After restarting web, we can now search for Antibodies:
+
+.. image:: https://user-images.githubusercontent.com/900055/40605069-063ff29a-6259-11e8-9295-3887dde0441f.png
+
+
 We can also specify an empty list of keys to search for *any* value.
 
 ::
@@ -119,11 +124,7 @@ We can also specify an empty list of keys to search for *any* value.
     # Top link
     omero config append omero.web.ui.top_links '["Any Value", {"viewname": "maprindex_anyvalue"}, {"title": "Find Any value"}]'
 
-After restarting web, we
-can now search for Antibodies or *all* Values in Key-Value pairs added by users:
-
-
-.. image:: https://user-images.githubusercontent.com/900055/40605069-063ff29a-6259-11e8-9295-3887dde0441f.png
+After restarting web, we can now search for any Value, such as "INCENP":
 
 .. image:: https://user-images.githubusercontent.com/900055/40605101-1cd1925c-6259-11e8-93a8-e72af2e570d3.png
 

--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ We can also specify an empty list of keys to search for *any* value.
     $ bin/omero config append omero.web.mapr.config '{"menu": "anyvalue", "config":{"default":["Any Value"], "all":[], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"Any"}}'
 
     # Top link
-    omero config append omero.web.ui.top_links '["Any Value", {"viewname": "maprindex_anyvalue"}, {"title": "Find Any value"}]'
+    omero config append omero.web.ui.top_links '["Any Value", {"viewname": "maprindex_anyvalue"}, {"title": "Find Any Value"}]'
 
 After restarting web, we can now search for any Value, such as "INCENP":
 

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,8 @@ attributes under the ``Gene Symbol`` and ``Gene Identifier`` keys.
 
 We can add a link to the top of the webclient page to take us to the mapr Genes search page.
 The ``viewname`` should be in the form ``maprindex_{menu}`` where ``{menu}`` is the the ``menu`` value in the previous config.
-In this example a link of ``Genes`` with tooltip ``Find Gene annotations`` will take us to the ``gene`` search page.
+In this example a link of ``Genes`` with tooltip ``Find Gene annotations`` will take us to the ``gene`` search page. The ``query_string`` parameters are added to the URL, with ``"experimenter": -1``
+specifying that we want to search across all users.
 
 ::
 
@@ -106,13 +107,19 @@ For example, to search for "Primary Antibody" or "Secondary Antibody" values, we
 
     $ bin/omero config append omero.web.mapr.config '{"menu": "antibody", "config":{"default":["Primary Antibody"], "all":["Primary Antibody", "Secondary Antibody"], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"Antibody"}}'
 
+    # Top link (without experimenter: -1)
+    $ bin/omero config append omero.web.ui.top_links '["Antibodies", {"viewname": "maprindex_antibody"}, {"title": "Find Antibody values"}]'
+
 We can also specify an empty list of keys to search for *any* value.
 
 ::
 
     $ bin/omero config append omero.web.mapr.config '{"menu": "anyvalue", "config":{"default":["Any Value"], "all":[], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"Any"}}'
 
-After configuring appropriate ``top_links`` for each of these and restarting web, we
+    # Top link
+    omero config append omero.web.ui.top_links '["Any Value", {"viewname": "maprindex_anyvalue"}, {"title": "Find Any value"}]'
+
+After restarting web, we
 can now search for Antibodies or *all* Values in Key-Value pairs added by users:
 
 


### PR DESCRIPTION
Adding the ```any:[]``` config to the docs.
This is what we are demo'ing at the OME meeting metadata workshop and is also found in the idr mapr config (see https://github.com/openmicroscopy/prod-playbooks/pull/67#issuecomment-392089315).

Page staged at https://github.com/will-moore/omero-mapr/tree/add_anyvalue_config_to_README