### PR TITLE
well index fix metadata general

### DIFF
--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -233,7 +233,7 @@ $(function () {
                             url = prefix+'metadata_details/'+orel+'/'+oid.split("-")[1]+'/';
                         }
                     } else if(orel=="well"){
-                        var well_index = selected[0]["index"];
+                        var well_index = selected[0]["index"] || 0;
                         url = '{% url "load_metadata_details" %}well/'+oid.split('-')[1]+'/';
                         data = {'index': well_index};
                     } else {


### PR DESCRIPTION
See https://www.openmicroscopy.org/qa2/qa/feedback/27241/. 

To test, with MAPR installed, search for a Well by ID and click on the Well in search results.
The Well (index=0) should load in the right panel.

NB: This took me a while to track down as I'd forgotten that I had MAPR installed locally so when I tried editing my local ```right_plugin.general.js.html``` I saw no changes, and the local code already had the bug fixed. Need to remember that any changes made to this file in ```openmicroscopy``` have to be duplicated in ```mapr```.