### PR TITLE
Support ?show=screen-123 for mapr jstree

### DIFF
--- a/omero_mapr/static/mapr/javascript/ome.mapr.js
+++ b/omero_mapr/static/mapr/javascript/ome.mapr.js
@@ -121,19 +121,24 @@ $(function () {
             var url = MAPANNOTATIONS.URLS.paths_to_object + '?' + show.replace('-', '=');
             $.getJSON(url, {'map.value': value}, function(data) {
                 if (data.paths && data.paths.length > 0) {
-                    // Just traverse the first path
-                    let pathToObj = data.paths[0];
+                    // Just traverse the first path, start looking at child of root
+                    let pathToObj = data.paths[0].slice(1);
                     // start at root node
-                    let node = jstreeInst.get_node('ul > li:first');
-                    // first look for 2nd node in path (first node is root)...
-                    // NB: Seems we don't need a callback on open_node for children to load before we
-                    // traverse down to the next level?!
-                    for (var p=1; p<pathToObj.length; p++) {
-                        let nodeData = pathToObj[p];
+                    let rootNode = jstreeInst.get_node('ul > li:first');
+
+                    function traverse(node, path) {
+                        if (path.length == 0) return;
+                        let nodeData = path[0];
                         node = inst.locate_node(nodeData.type + '-' + nodeData.id, node)[0];
-                        if (!node) break;
-                        inst.open_node(node);
+                        if (!node) {
+                        }
+                        inst.open_node(node, function(){
+                            path = path.slice(1);
+                            traverse(node, path);
+                        });
                     }
+                    // start recursive traversing...
+                    traverse(rootNode, pathToObj);
                 }
             });
         }

--- a/omero_mapr/static/mapr/javascript/ome.mapr.js
+++ b/omero_mapr/static/mapr/javascript/ome.mapr.js
@@ -104,4 +104,34 @@ $(function () {
         return sortingStrategy(node1, node2);
     };
 
+
+    // ----- Show -----
+    // e.g. /mapr/gene/?value=CDC5&show=screen-51
+    $('#dataTree').on('load_node.jstree', function(e, data) {
+        // If we're not ROOT node, ignore
+        if (data.node.id !== 'j1_1') return;
+        // Check for e.g. ?show=screen-51
+        var show = OME.getURLParameter("show");
+        if (show) {
+            // Find node that contains study:
+            var rootNode = jstreeInst.get_node(data.node.id);
+            rootNode.children.forEach(id => {
+                // Open each child of root node...
+                jstreeInst.open_node(id,
+                    function(node) {
+                        // Check children (studies) for match with show, e.g. 'screen-51'
+                        jstreeInst.get_node(node.id).children.forEach(node_id => {
+                            var node = jstreeInst.get_node(node_id);
+                            // Open and Select matching node
+                            if (node.type + '-' + node.data.id == show) {
+                                jstreeInst.open_node(node_id);
+                                jstreeInst.select_node(node_id);
+                            }
+                        });
+                    }
+                );
+            })
+        }
+    });
+
 });

--- a/omero_mapr/static/mapr/javascript/ome.mapr.js
+++ b/omero_mapr/static/mapr/javascript/ome.mapr.js
@@ -127,13 +127,17 @@ $(function () {
                     let rootNode = jstreeInst.get_node('ul > li:first');
 
                     function traverse(node, path) {
-                        if (path.length == 0) return;
+                        if (path.length == 0) {
+                            inst.select_node(node);
+                            return;
+                        }
                         let nodeData = path[0];
                         node = inst.locate_node(nodeData.type + '-' + nodeData.id, node)[0];
                         if (!node) {
+                            return;
                         }
+                        path = path.slice(1);
                         inst.open_node(node, function(){
-                            path = path.slice(1);
                             traverse(node, path);
                         });
                     }

--- a/omero_mapr/templates/mapr/base_mapr.html
+++ b/omero_mapr/templates/mapr/base_mapr.html
@@ -102,6 +102,8 @@
 
         var MAPANNOTATIONS = {}
         MAPANNOTATIONS.URLS = {'static_webclient': "{% static 'mapr' %}/"};
+        MAPANNOTATIONS.URLS.maprindex = "{% url 'maprindex' %}";
+        MAPANNOTATIONS.URLS.paths_to_object = "{% url 'mapannotations_api_paths_to_object' menu %}";
         MAPANNOTATIONS.URLS.autocomplete = "{% url 'mapannotations_autocomplete' menu %}";
         MAPANNOTATIONS.URLS.autocomplete_default = "{% url 'mapannotations_api_experimenters' menu %}";
 

--- a/omero_mapr/views.py
+++ b/omero_mapr/views.py
@@ -183,7 +183,7 @@ def index(request, menu, conn=None, url=None, **kwargs):
     kwargs['template'] = "mapr/base_mapr.html"
     context = _webclient_load_template(request, menu,
                                        conn=conn, url=url, **kwargs)
-    context['active_user'] = context['active_user'] or {'id': -1}
+    context['active_user'] = context.get('active_user', {'id': -1})
     context['mapr_conf'] = {
         'menu': menu,
         'menu_all': mapr_settings.CONFIG[menu]['all'],


### PR DESCRIPTION
This adds support for the URL e.g. ```?show=screen-2``` so that we can link to a Study *within* a Gene etc.
This may be a useful entry point if we use a different UI / App to do the initial mapr query, then we want to link to a particular study within a matching term in the mapr app.
E.g. http://web-dev-merge.openmicroscopy.org/mapr/gene/?value=CDK5RAP2&show=project-4501 (user-3)

In mapr, this will load Genes that match value ```CDK5RAP2```. With the 'show' query, we load the top level gene nodes of the tree, to check their "study" children for a match with the 'show' query. If we find a match then this node is selected and expanded.
NB: This is a different approach from the ```webclient/?show=image-2``` where the node may be deep in the tree and needs us to load the "path" to this node before expanding all the nodes along the path. Here, we know that the "study" will be one level below the "Genes" that are children of the root node. So we can simply expand each and look for the "study". This will expand some nodes unnecessarily, but the number will be small since most e.g. Genes don't have many homologues (not many children of the root node).

To test:
 - Browse e.g. Gene, Antibody, etc pages in mapr. Enter a term, e.g."CDC5" pick from auto-complete etc to show studies.
 - Note a study ID, e.g. screen-51
 - Construct URL of the form  ```/mapr/gene/?value=CDC5&show=screen-51```
 - Enter this URL in the browser. The matching Gene(s) should be loaded as normal, the child studies loaded and the matching one selected and expanded.

![Screen Shot 2019-04-25 at 15 41 08](https://user-images.githubusercontent.com/900055/56744534-9aa4cb00-6770-11e9-8983-29297182898e.png)
