### PR TITLE
Add /api/config/ to return mapr_settings.CONFIG as JSON

### DIFF
--- a/omero_mapr/urls.py
+++ b/omero_mapr/urls.py
@@ -55,6 +55,8 @@ urlpatterns += (
             query_string=True)),
         name="maprindex"),
 
+    url(r'^api/config/$', views.api_mapr_config),
+
     url(r'^api/(?P<menu>%s)/count/$' % (CONFIG_REGEX),
         views.api_experimenter_list,
         name='mapannotations_api_experimenters'),

--- a/omero_mapr/views.py
+++ b/omero_mapr/views.py
@@ -197,6 +197,11 @@ def index(request, menu, conn=None, url=None, **kwargs):
     return context
 
 
+def api_mapr_config(request):
+    """Return mapr_settings.CONFIG as JSON."""
+    return JsonResponse(mapr_settings.CONFIG)
+
+
 @login_required()
 def api_paths_to_object(request, menu=None, conn=None, **kwargs):
     """


### PR DESCRIPTION
This makes the mapr_settings.CONFIG available as JSON data, so it can be used by other apps.
E.g. https://github.com/ome/omero-gallery/pull/25/

To test:
 - go to ```/mapr/api/config/``` E.g. http://web-dev-merge.openmicroscopy.org/mapr/api/config/
 - Should see JSON that corresponds to ```omero.web.mapr.config``` setting.

![Screen Shot 2019-04-29 at 15 59 50](https://user-images.githubusercontent.com/900055/56905393-03a18100-6a98-11e9-9200-790805a3218a.png)
