### PR TITLE
Selected values can have custom transformations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,7 @@ This can be useful for cross-referencing public identifiers.
 * ``namespace``: Only apply to key-value pairs in this namespace
 * ``key``: The key name to match
 * ``value``: The replacement template value, all instances of ``{{value}}`` will be replaced with the original value.
+
 For example, this will convert all values in namespace ``idr.openmicroscopy.org/study/info`` to PubMed URLs where the key is ``PubMed ID`` and the value is the PubMed Identifier::
 
     $ bin/omero config set -- omero.web.mapr.metadata_kv_substitutions '[{"namespace": "idr.openmicroscopy.org/study/info", "key": "PubMed ID", "value": "<a href=\"https://www.ncbi.nlm.nih.gov/pubmed/{{value}}\">{{value}}</a>"}]'

--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,17 @@ You should now be able to browse to a ``Genes`` page and search for
 ``CDC20`` or ``ENSG00000117399``.
 
 
+Value substitutions
+-------------------
+
+Mapr can automatically post-process values based on matching keys.
+This can be useful for cross-referencing public identifiers.
+``omero.web.mapr.metadata_kv_substitutions`` is a map of Map-annotation keys to templated values where all instance of ``{{value}}`` will be replaced with the original value.
+For example, this will convert all values to PubMed URLs where the key is ``PubMed ID`` and the value is the PubMed Identifier::
+
+    $ bin/omero config set -- omero.web.mapr.metadata_kv_substitutions '{"PubMed ID": "<a href=\"https://www.ncbi.nlm.nih.gov/pubmed/{{value}}\">{{value}}</a>"}'
+
+
 Testing
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -147,10 +147,14 @@ Value substitutions
 
 Mapr can automatically post-process values based on matching keys.
 This can be useful for cross-referencing public identifiers.
-``omero.web.mapr.metadata_kv_substitutions`` is a map of Map-annotation keys to templated values where all instance of ``{{value}}`` will be replaced with the original value.
-For example, this will convert all values to PubMed URLs where the key is ``PubMed ID`` and the value is the PubMed Identifier::
+``omero.web.mapr.metadata_kv_substitutions`` is a list of dictionaries with the following required fields:
 
-    $ bin/omero config set -- omero.web.mapr.metadata_kv_substitutions '{"PubMed ID": "<a href=\"https://www.ncbi.nlm.nih.gov/pubmed/{{value}}\">{{value}}</a>"}'
+* ``namespace``: Only apply to key-value pairs in this namespace
+* ``key``: The key name to match
+# ``value``: The replacement template value, all instances of ``{{value}}`` will be replaced with the original value.
+For example, this will convert all values in namespace ``idr.openmicroscopy.org/study/info`` to PubMed URLs where the key is ``PubMed ID`` and the value is the PubMed Identifier::
+
+    $ bin/omero config set -- omero.web.mapr.metadata_kv_substitutions '[{"namespace": "idr.openmicroscopy.org/study/info", "key": "PubMed ID", "value": "<a href=\"https://www.ncbi.nlm.nih.gov/pubmed/{{value}}\">{{value}}</a>"}'
 
 
 Testing

--- a/README.rst
+++ b/README.rst
@@ -151,10 +151,10 @@ This can be useful for cross-referencing public identifiers.
 
 * ``namespace``: Only apply to key-value pairs in this namespace
 * ``key``: The key name to match
-# ``value``: The replacement template value, all instances of ``{{value}}`` will be replaced with the original value.
+* ``value``: The replacement template value, all instances of ``{{value}}`` will be replaced with the original value.
 For example, this will convert all values in namespace ``idr.openmicroscopy.org/study/info`` to PubMed URLs where the key is ``PubMed ID`` and the value is the PubMed Identifier::
 
-    $ bin/omero config set -- omero.web.mapr.metadata_kv_substitutions '[{"namespace": "idr.openmicroscopy.org/study/info", "key": "PubMed ID", "value": "<a href=\"https://www.ncbi.nlm.nih.gov/pubmed/{{value}}\">{{value}}</a>"}'
+    $ bin/omero config set -- omero.web.mapr.metadata_kv_substitutions '[{"namespace": "idr.openmicroscopy.org/study/info", "key": "PubMed ID", "value": "<a href=\"https://www.ncbi.nlm.nih.gov/pubmed/{{value}}\">{{value}}</a>"}]'
 
 
 Testing

--- a/omero_mapr/mapr_settings.py
+++ b/omero_mapr/mapr_settings.py
@@ -23,6 +23,7 @@
 import sys
 import os
 
+import json
 from django.conf import settings
 from omeroweb.settings import process_custom_settings, report_settings
 from omero_mapr.utils import config_list_to_dict
@@ -32,6 +33,8 @@ from omero_mapr.utils import config_list_to_dict
 MAPR_SETTINGS_MAPPING = {
     "omero.web.mapr.config":
         ["MAPR_CONFIG", "[]", config_list_to_dict, None],
+    "omero.web.mapr.metadata_kv_substitutions":
+        ["MAPR_KV_SUBST", "{}", json.loads, None],
     "omero.web.mapr.favicon":
         ["MAPR_DEFAULT_FAVICON",
          os.path.join(os.path.dirname(__file__),
@@ -58,6 +61,8 @@ def prefix_setting(suffix, default):
 class MaprSettings(object):
 
     CONFIG = prefix_setting('CONFIG', MAPR_CONFIG)  # noqa
+    KV_SUBSTS = prefix_setting('KV_SUBST',
+                               MAPR_KV_SUBST)  # noqa
     DEFAULT_FAVICON = prefix_setting('DEFAULT_FAVICON',
                                      MAPR_DEFAULT_FAVICON)  # noqa
     FAVICON_WEBSERVICE = prefix_setting('FAVICON_WEBSERVICE',

--- a/omero_mapr/mapr_settings.py
+++ b/omero_mapr/mapr_settings.py
@@ -23,10 +23,12 @@
 import sys
 import os
 
-import json
 from django.conf import settings
 from omeroweb.settings import process_custom_settings, report_settings
-from omero_mapr.utils import config_list_to_dict
+from omero_mapr.utils import (
+    config_list_to_dict,
+    kvsubst_list_to_dict,
+)
 
 
 # load settings
@@ -34,7 +36,7 @@ MAPR_SETTINGS_MAPPING = {
     "omero.web.mapr.config":
         ["MAPR_CONFIG", "[]", config_list_to_dict, None],
     "omero.web.mapr.metadata_kv_substitutions":
-        ["MAPR_KV_SUBST", "{}", json.loads, None],
+        ["MAPR_KV_SUBST", "[]", kvsubst_list_to_dict, None],
     "omero.web.mapr.favicon":
         ["MAPR_DEFAULT_FAVICON",
          os.path.join(os.path.dirname(__file__),

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -67,84 +67,89 @@ var isURL = function(input) {
 
 var old_linkify_element = OME.linkify_element;
 OME.linkify_element = function(elements) {
-    if ($("table.keyValueTable").is(elements) ) {
+    elements.each(function() {
         var mapr_menu = {% mapr_menu_config %};
         var mapr_kvsubst = {% mapr_kvsubst_config %};
 
-        // Replace namespace with label
-        var ns2menu = {};
-        $.each( mapr_menu, function( i, obj ) {
-            $.each( obj['ns'], function( j, ns ) {
-                ns2menu[ns] = obj['label'];
-            });
-        });
-        var t = elements.find("thead").find("tr");
-        var $targets = t.filter(function() {
-            if ($(this).attr('title') in ns2menu) {
-                var old = $(this).children("th").text();
-                $(this).children("th").html("<h1>" + ns2menu[$(this).attr('title')] + "</h1>");
-                $(this).closest('tr').nextAll("tr.tooltip").children('th').children('span')
-                    .append('<br/><b>NS:</b> ' + old + '');
-            }
-        });
+        if ($(this).is("table.keyValueTable")) {
+            var element = $(this);
 
-        // linkify also mapr keys and convert URL to icons
-        var menu2keys = [];
-        var keys2menu = {};
-        $.each( mapr_menu, function( i, obj ) {
-            $.merge(menu2keys, obj['all']);
-            $.each( obj['all'], function( j, d ) {
-                keys2menu[d] = i
+            // Replace namespace with label
+            var ns2menu = {};
+            $.each( mapr_menu, function( i, obj ) {
+                $.each( obj['ns'], function( j, ns ) {
+                    ns2menu[ns] = obj['label'];
+                });
             });
-        });
-
-        elements.find("tbody").find("tr").each(function() {
-            var $row = $(this);
-            if (!$row.parent().parent().hasClass("editableKeyValueTable")) {
-                var $chlabel = $row.children("td:nth-child(1)");
-                var $chvalue = $row.children("td:nth-child(2)");
-                // if label matchs mapr PK
-                var _key = $chlabel.text().trim();
-                var _val = $chvalue.text().trim();
-                var _tkey = _key.replace(/url/i, "").trim();
-                if ( $.inArray(_tkey, menu2keys) > -1  ) {
-                    $chvalue.html(iconify($chvalue.text()));
-                    if ( $.inArray(_key, menu2keys) > -1 ) {
-                        if ( _key in keys2menu && keys2menu[_key] !== undefined ) {
-                            // create mapr url
-                            var _url = location.protocol + "//" + location.host + "{% url 'maprindex' %}" + keys2menu[_key] +"/?value=" + encodeURIComponent(_val);
-                            $chvalue.html($chvalue.html().replace(_val, '<a href="' + _url + '">' + _val + '</a>'));
-                        }
-                    }
-                    if ( _key.match(new RegExp("url", "i"))  ) {
-                        // Find nearest URL
-                        //var $target1 = $row.prev('tr');
-                        var $target = $row.parent().find("tr").filter(function() {
-                            var $chl = $(this).children("td:nth-child(1)");
-                            var $chv = $(this).children("td:nth-child(2)");
-                            var $chs = $row.children("td:nth-child(2)").find("span a img").attr('src');
-                            return $chl.text() === _tkey && (($chv.find("a").text().lenght > 0 && ($chs.indexOf(encodeURIComponent($chv.find("a").text())) >= 0 || $chs.indexOf($chv.find("a").text()) >= 0)) || ($chv.text().length > 0 && ($chs.indexOf(encodeURIComponent($chv.text())) >= 0 || $chs.indexOf($chv.text()) >= 0)));
-                        }).closest("tr");
-                        if ( $target.length ) {
-                            var $targetchlabel = $target.children("td:nth-child(1)");
-                            var $targetchvalue = $target.children("td:nth-child(2)");
-                            // add icon to the target and hide
-                            $targetchvalue.append($chvalue.html());
-                            $row.hide();
-                        }
-                    }
-                } else if (_key in mapr_kvsubst) {
-                    var subst = mapr_kvsubst[_key].replace(/\{\{value\}\}/g, _val);
-                    $chvalue.empty().html(subst);
-                } else {
-                    old_linkify_element($row);
+            var t = element.find("thead").find("tr");
+            var namespace = (t.attr("title") || "");
+            var $targets = t.filter(function() {
+                if ($(this).attr('title') in ns2menu) {
+                    var old = $(this).children("th").text();
+                    $(this).children("th").html("<h1>" + ns2menu[$(this).attr('title')] + "</h1>");
+                    $(this).closest('tr').nextAll("tr.tooltip").children('th').children('span')
+                        .append('<br/><b>NS:</b> ' + old + '');
                 }
-            }
+            });
 
-        });
-    } else {
-        old_linkify_element(elements);
-    }
+            // linkify also mapr keys and convert URL to icons
+            var menu2keys = [];
+            var keys2menu = {};
+            $.each( mapr_menu, function( i, obj ) {
+                $.merge(menu2keys, obj['all']);
+                $.each( obj['all'], function( j, d ) {
+                    keys2menu[d] = i
+                });
+            });
+
+            element.find("tbody").find("tr").each(function() {
+                var $row = $(this);
+                if (!$row.parent().parent().hasClass("editableKeyValueTable")) {
+                    var $chlabel = $row.children("td:nth-child(1)");
+                    var $chvalue = $row.children("td:nth-child(2)");
+                    // if label matchs mapr PK
+                    var _key = $chlabel.text().trim();
+                    var _val = $chvalue.text().trim();
+                    var _tkey = _key.replace(/url/i, "").trim();
+                    if ( $.inArray(_tkey, menu2keys) > -1  ) {
+                        $chvalue.html(iconify($chvalue.text()));
+                        if ( $.inArray(_key, menu2keys) > -1 ) {
+                            if ( _key in keys2menu && keys2menu[_key] !== undefined ) {
+                                // create mapr url
+                                var _url = location.protocol + "//" + location.host + "{% url 'maprindex' %}" + keys2menu[_key] +"/?value=" + encodeURIComponent(_val);
+                                $chvalue.html($chvalue.html().replace(_val, '<a href="' + _url + '">' + _val + '</a>'));
+                            }
+                        }
+                        if ( _key.match(new RegExp("url", "i"))  ) {
+                            // Find nearest URL
+                            //var $target1 = $row.prev('tr');
+                            var $target = $row.parent().find("tr").filter(function() {
+                                var $chl = $(this).children("td:nth-child(1)");
+                                var $chv = $(this).children("td:nth-child(2)");
+                                var $chs = $row.children("td:nth-child(2)").find("span a img").attr('src');
+                                return $chl.text() === _tkey && (($chv.find("a").text().lenght > 0 && ($chs.indexOf(encodeURIComponent($chv.find("a").text())) >= 0 || $chs.indexOf($chv.find("a").text()) >= 0)) || ($chv.text().length > 0 && ($chs.indexOf(encodeURIComponent($chv.text())) >= 0 || $chs.indexOf($chv.text()) >= 0)));
+                            }).closest("tr");
+                            if ( $target.length ) {
+                                var $targetchlabel = $target.children("td:nth-child(1)");
+                                var $targetchvalue = $target.children("td:nth-child(2)");
+                                // add icon to the target and hide
+                                $targetchvalue.append($chvalue.html());
+                                $row.hide();
+                            }
+                        }
+                    } else if (namespace in mapr_kvsubst && _key in mapr_kvsubst[namespace]) {
+                        var subst = mapr_kvsubst[namespace][_key].replace(/\{\{value\}\}/g, _val);
+                        $chvalue.empty().html(subst);
+                    } else {
+                        old_linkify_element($row);
+                    }
+                }
+
+            });
+        } else {
+            old_linkify_element($(this));
+        }
+    });
 };
 
 

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -114,8 +114,9 @@ OME.linkify_element = function(elements) {
                     var $chvalue = $row.children("td:nth-child(2)");
                     // if label matchs mapr PK
                     var _key = $chlabel.text().trim();
+                    var _val = $chvalue.text().trim();
                     // This returns the HTML escaped value of the text
-                    var _val = $chvalue.html().trim();
+                    var _valEscaped = $chvalue.html().trim();
                     var _tkey = _key.replace(/url/i, "").trim();
                     if ( $.inArray(_tkey, menu2keys) > -1  ) {
                         $chvalue.html(iconify($chvalue.text()));
@@ -123,7 +124,7 @@ OME.linkify_element = function(elements) {
                             if ( _key in keys2menu && keys2menu[_key] !== undefined ) {
                                 // create mapr url
                                 var _url = location.protocol + "//" + location.host + "{% url 'maprindex' %}" + keys2menu[_key] +"/?value=" + encodeURIComponent(_val);
-                                $chvalue.html($chvalue.html().replace(_val, '<a href="' + _url + '">' + _val + '</a>'));
+                                $chvalue.html($chvalue.html().replace(_val, '<a href="' + _url + '">' + _valEscaped + '</a>'));
                             }
                         }
                         if ( _key.match(new RegExp("url", "i"))  ) {
@@ -144,7 +145,7 @@ OME.linkify_element = function(elements) {
                             }
                         }
                     } else if (namespace in mapr_kvsubst && _key in mapr_kvsubst[namespace]) {
-                        var subst = mapr_kvsubst[namespace][_key].replace(/\{\{value\}\}/g, _val);
+                        var subst = mapr_kvsubst[namespace][_key].replace(/\{\{value\}\}/g, _valEscaped);
                         $chvalue.empty().html(subst);
                     } else {
                         old_linkify_element($row);

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -65,6 +65,18 @@ var isURL = function(input) {
     return urlRegex.test(input);
 };
 
+var mapValueEscapeHtml = function(string) {
+    return String(string).replace(/[&<>"']/g, function (s) {
+        return {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&apos;'
+        }[s];
+    });
+};
+
 var old_linkify_element = OME.linkify_element;
 OME.linkify_element = function(elements) {
     elements.each(function() {
@@ -138,7 +150,7 @@ OME.linkify_element = function(elements) {
                             }
                         }
                     } else if (namespace in mapr_kvsubst && _key in mapr_kvsubst[namespace]) {
-                        var subst = mapr_kvsubst[namespace][_key].replace(/\{\{value\}\}/g, _val);
+                        var subst = mapr_kvsubst[namespace][_key].replace(/\{\{value\}\}/g, mapValueEscapeHtml(_val));
                         $chvalue.empty().html(subst);
                     } else {
                         old_linkify_element($row);

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -69,6 +69,7 @@ var old_linkify_element = OME.linkify_element;
 OME.linkify_element = function(elements) {
     if ($("table.keyValueTable").is(elements) ) {
         var mapr_menu = {% mapr_menu_config %};
+        var mapr_kvsubst = {% mapr_kvsubst_config %};
 
         // Replace namespace with label
         var ns2menu = {};
@@ -132,6 +133,9 @@ OME.linkify_element = function(elements) {
                             $row.hide();
                         }
                     }
+                } else if (_key in mapr_kvsubst) {
+                    var subst = mapr_kvsubst[_key].replace(/\{\{value\}\}/g, _val);
+                    $chvalue.empty().html(subst);
                 } else {
                     old_linkify_element($row);
                 }

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -65,18 +65,6 @@ var isURL = function(input) {
     return urlRegex.test(input);
 };
 
-var mapValueEscapeHtml = function(string) {
-    return String(string).replace(/[&<>"']/g, function (s) {
-        return {
-            '&': '&amp;',
-            '<': '&lt;',
-            '>': '&gt;',
-            '"': '&quot;',
-            "'": '&apos;'
-        }[s];
-    });
-};
-
 var old_linkify_element = OME.linkify_element;
 OME.linkify_element = function(elements) {
     elements.each(function() {
@@ -121,7 +109,8 @@ OME.linkify_element = function(elements) {
                     var $chvalue = $row.children("td:nth-child(2)");
                     // if label matchs mapr PK
                     var _key = $chlabel.text().trim();
-                    var _val = $chvalue.text().trim();
+                    // This returns the HTML escaped value of the text
+                    var _val = $chvalue.html().trim();
                     var _tkey = _key.replace(/url/i, "").trim();
                     if ( $.inArray(_tkey, menu2keys) > -1  ) {
                         $chvalue.html(iconify($chvalue.text()));
@@ -150,7 +139,7 @@ OME.linkify_element = function(elements) {
                             }
                         }
                     } else if (namespace in mapr_kvsubst && _key in mapr_kvsubst[namespace]) {
-                        var subst = mapr_kvsubst[namespace][_key].replace(/\{\{value\}\}/g, mapValueEscapeHtml(_val));
+                        var subst = mapr_kvsubst[namespace][_key].replace(/\{\{value\}\}/g, _val);
                         $chvalue.empty().html(subst);
                     } else {
                         old_linkify_element($row);

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -96,10 +96,15 @@ OME.linkify_element = function(elements) {
             var menu2keys = [];
             var keys2menu = {};
             $.each( mapr_menu, function( i, obj ) {
+                // FIXME: This should prevent keys-values in other namespace being linked
+                // but it also breaks the automatic icons for external URLs
+                // https://github.com/ome/omero-mapr/issues/48
+                //if (mapr_menu["ns"] == namespace) {
                 $.merge(menu2keys, obj['all']);
                 $.each( obj['all'], function( j, d ) {
                     keys2menu[d] = i
                 });
+                //}
             });
 
             element.find("tbody").find("tr").each(function() {

--- a/omero_mapr/templatetags/mapr_tags.py
+++ b/omero_mapr/templatetags/mapr_tags.py
@@ -43,5 +43,4 @@ def mapr_menu_config():
 
 @register.simple_tag
 def mapr_kvsubst_config():
-    logger.debug('mapr_settings.KV_SUBSTS %s', mapr_settings.KV_SUBSTS)
     return mark_safe(json.dumps(mapr_settings.KV_SUBSTS))

--- a/omero_mapr/templatetags/mapr_tags.py
+++ b/omero_mapr/templatetags/mapr_tags.py
@@ -39,3 +39,9 @@ logger = logging.getLogger(__name__)
 @register.simple_tag
 def mapr_menu_config():
     return mark_safe(json.dumps(mapr_settings.CONFIG))
+
+
+@register.simple_tag
+def mapr_kvsubst_config():
+    logger.debug('mapr_settings.KV_SUBSTS %s', mapr_settings.KV_SUBSTS)
+    return mark_safe(json.dumps(mapr_settings.KV_SUBSTS))

--- a/omero_mapr/utils/__init__.py
+++ b/omero_mapr/utils/__init__.py
@@ -32,3 +32,18 @@ def config_list_to_dict(config_list):
             if i.get('config', None) is not None:
                 config_dict[k] = i['config']
     return config_dict
+
+
+def kvsubst_list_to_dict(kvsubst_list):
+    kvsubst_dict = {}
+    for i in json.loads(kvsubst_list):
+        namespace = i.get('namespace', '')
+        key = i.get('key', None)
+        value = i.get('value', None)
+        if key is not None and value is not None:
+            try:
+                kvsubst_dict[namespace][key] = value
+            except KeyError:
+                kvsubst_dict[namespace] = {}
+                kvsubst_dict[namespace][key] = value
+    return kvsubst_dict


### PR DESCRIPTION
`omero.web.mapr.metadata_kv_substitutions` is a dict of Keys:Value-transformations that allows values in a map-annotation to be post-processed using custom HTML, e.g. to convert an identifier into a hyperlink

For example:
```
omero config set -- omero.web.mapr.metadata_kv_substitutions '[{
    "namespace": "idr.openmicroscopy.org/study/info",
    "key": "PubMed ID",
    "value": "<a href=\"https://www.ncbi.nlm.nih.gov/pubmed/{{value}}\">{{value}}</a>"
}]'
```
will convert a key-value pair `PubMed ID`:`28775673` to
`PubMed ID`:`<a href="https://www.ncbi.nlm.nih.gov/pubmed/28775673">28775673</a>`

```
omero config set -- omero.web.mapr.metadata_kv_substitutions '[{
    "namespace": "idr.openmicroscopy.org/study/info",
    "key": "Study Type",
    "value": "<span style=\"color:red;\"> !!! <a href=\"https://www.google.com/search?q={{value}}\" target=\"_blank\">{{value}}</a> !!! </span>"
}]'
```
will convert all values with Key `Study Type` to a Google link, surrounded by red `!!!`:
![Screen Shot 2019-05-15 at 18 43 55](https://user-images.githubusercontent.com/1644105/57797023-69049b80-7741-11e9-8089-07ad76c1f96c.png)

--exclude