### PR TITLE
Use active_user.id instead of object in autocomplete REST data

### DIFF
--- a/omero_mapr/static/mapr/javascript/ome.mapr.ui.autocomplete.js
+++ b/omero_mapr/static/mapr/javascript/ome.mapr.ui.autocomplete.js
@@ -40,7 +40,7 @@ $(function () {
                     value: $('#id_case_sensitive').is(":checked") ? request.term : request.term.toLowerCase(),
                     query: true,
                     case_sensitive: $('#id_case_sensitive').is(":checked"),
-                    experimenter_id: WEBCLIENT.active_user,
+                    experimenter_id: WEBCLIENT.active_user.id,
                     group: WEBCLIENT.active_group_id,
                 },
                 success: function(data) {


### PR DESCRIPTION
Noticed while comparing URLs with those from IDR gallery.

Previously URLs to load auto-complete data looked like e.g.
```
http://localhost:4080/mapr/api/autocomplete/gene/?... ..experimenter_id%5Bid%5D=-1&experimenter_id%5BfullName%5D=
```
since the whole ```WEBCLIENT.active_user``` object was being serialised to the query.
With this fix, it should now look like ```experimenter_id=-1``` (inspect XHR requests in devtools).

To test:
 - Go to mapr, e.g. https://merge-ci.openmicroscopy.org/web/mapr/anyvalue/
 - Open devtools in your browser, click on Network tab and XHR.
 - Start typing in the mapr search input (above the tree). It doesn't matter too much what you type but it will look for 'any' matching Values from map annotations.
 - You should see requests in the network tab that have ```experimenter_id=123``` in them, e.g. 
```https://merge-ci.openmicroscopy.org/web/mapr/api/autocomplete/anyvalue/?value=in&query=true&case_sensitive=false&experimenter_id=454&group=454&_=1568968925363```