### PR TITLE
Fix show when value has whitespace

### DIFF
--- a/omero_mapr/static/mapr/javascript/ome.mapr.js
+++ b/omero_mapr/static/mapr/javascript/ome.mapr.js
@@ -115,6 +115,8 @@ $(function () {
         // Check for e.g. ?show=screen-51
         var show = OME.getURLParameter("show");
         var value = OME.getURLParameter("value");
+        // Handle whitespace in the value ('%20')
+        value = value.replace(/%20/g, ' ');
         if (show && value) {
             // Find node that contains study:
             // /mapr/api/gene/paths_to_object/?map.value=CEP120&project=18328

--- a/omero_mapr/static/mapr/javascript/ome.mapr.js
+++ b/omero_mapr/static/mapr/javascript/ome.mapr.js
@@ -115,8 +115,8 @@ $(function () {
         // Check for e.g. ?show=screen-51
         var show = OME.getURLParameter("show");
         var value = OME.getURLParameter("value");
-        // Handle whitespace in the value ('%20')
-        value = value.replace(/%20/g, ' ');
+        // Handle whitespace or other characters
+        value = decodeURI(value);
         if (show && value) {
             // Find node that contains study:
             // /mapr/api/gene/paths_to_object/?map.value=CEP120&project=18328


### PR DESCRIPTION
Fixes bug reported by @jrswedlow 

To test try e.g.
http://web-dev-merge.openmicroscopy.org/mapr/gene/?value=Kif2C%20(AB)&show=plate-4401
This should find the plate in the jsTree and select it.