### PR TITLE
Reactivate test-infra with 5.6.0-m2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,11 @@ python:
 services:
   - docker
 
-# before_install:
-#   - git clone git://github.com/ome/omero-test-infra .omero
+before_install:
+  - git clone git://github.com/ome/omero-test-infra .omero
 
 script:
-  # - .omero/docker app
-  true
+  - .omero/docker app
 
 deploy:
   provider: pypi

--- a/omero_mapr/urls.py
+++ b/omero_mapr/urls.py
@@ -33,7 +33,10 @@ reverse_lazy = lazy(reverse, str)
 
 # concatenate aliases to use in url regex
 CONFIG_REGEX = "(%s)" % ("|".join(mapr_settings.CONFIG))
-DEFAULT_CONFIG = list(mapr_settings.CONFIG.keys())[0]
+CONFIG_KEYS = list(mapr_settings.CONFIG.keys())
+DEFAULT_CONFIG = None
+if CONFIG_KEYS:
+    DEFAULT_CONFIG = CONFIG_KEYS[0]
 
 urlpatterns = []
 

--- a/omero_mapr/views.py
+++ b/omero_mapr/views.py
@@ -30,6 +30,7 @@ except ImportError:
     from urlparse import urlparse
 
 from Ice import Exception as IceException
+import omero.all  # noqa
 from omero import ApiUsageException, ServerError
 
 from django.conf import settings


### PR DESCRIPTION
Latest omero-web-docker image (5.6.0-m2-0) should allow imports.