### PR TITLE
Reactivate infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,11 @@ python:
 services:
   - docker
 
-# before_install:
-#   - git clone git://github.com/ome/omero-test-infra .omero
+before_install:
+  - git clone git://github.com/ome/omero-test-infra .omero
 
 script:
-  # - .omero/docker app
-  true
+  - .omero/docker app
 
 deploy:
   provider: pypi

--- a/omero_mapr/__init__.py
+++ b/omero_mapr/__init__.py
@@ -24,10 +24,12 @@
 
 
 from omero_mapr.utils.version import get_version
-
+from . import urls
 
 VERSION = (0, 4, 0, "dev2")
 
 __version__ = get_version(VERSION)
 
 default_app_config = 'omero_mapr.apps.MaprAppConfig'
+
+print(urls.__file__)


### PR DESCRIPTION
This tests ```omero-test-infra``` when the ```omero_mapr/__init__.py``` imports the ```urls.py```.
I think we often don't see the failure of ```urls.py``` to import because it doesn't happen when the omero_mapr module itself is imported.
