### PR TITLE
Mapr value icon: match with previous row

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,16 @@ You should now be able to browse to a ``Genes`` page and search for
 ``CDC20`` or ``ENSG00000117399``.
 
 
+External URL Favicons
+^^^^^^^^^^^^^^^^^^^^^
+
+Mapr can automatically convert external URLs in mapr categories to clickable favicons .
+OMERO.web must be configured with the Django redis cache https://docs.openmicroscopy.org/omero/5/sysadmins/unix/install-web/walkthrough/omeroweb-install-centos7-ice3.6.html?highlight=redis#configuring-omero-web
+
+To use this feature the mapr category key-value pair such as `Gene Identifier` must be followed by a key called `Gene Identifier URL`.
+The `Gene Identifier URL` key-value pair will be hidden.
+
+
 Testing
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -145,11 +145,11 @@ You should now be able to browse to a ``Genes`` page and search for
 External URL Favicons
 ^^^^^^^^^^^^^^^^^^^^^
 
-Mapr can automatically convert external URLs in mapr categories to clickable favicons .
-OMERO.web must be configured with the Django redis cache https://docs.openmicroscopy.org/omero/5/sysadmins/unix/install-web/walkthrough/omeroweb-install-centos7-ice3.6.html?highlight=redis#configuring-omero-web
+Mapr can automatically convert external URLs in mapr categories to clickable favicons.
+OMERO.web must be configured with the Django redis cache https://docs.openmicroscopy.org/omero/5/sysadmins/unix/install-web/walkthrough/omeroweb-install-centos7-ice3.6.html?highlight=redis#configuring-omero-web which is used to cached the favicons that are obtained using a Google service.
 
 To use this feature the mapr category key-value pair such as `Gene Identifier` must be followed by a key called `Gene Identifier URL`.
-The `Gene Identifier URL` key-value pair will be hidden.
+A favicon linked to the external URL will be appended to the `Gene Identifier` row, and the `Gene Identifier URL` key-value pair will be hidden.
 
 
 Testing

--- a/README.rst
+++ b/README.rst
@@ -145,11 +145,15 @@ You should now be able to browse to a ``Genes`` page and search for
 External URL Favicons
 ^^^^^^^^^^^^^^^^^^^^^
 
-Mapr can automatically convert external URLs in mapr categories to clickable favicons.
-OMERO.web must be configured with the Django redis cache https://docs.openmicroscopy.org/omero/5/sysadmins/unix/install-web/walkthrough/omeroweb-install-centos7-ice3.6.html?highlight=redis#configuring-omero-web which is used to cached the favicons that are obtained using a Google service.
-
-To use this feature the mapr category key-value pair such as `Gene Identifier` must be followed by a key called `Gene Identifier URL`.
-A favicon linked to the external URL will be appended to the `Gene Identifier` row, and the `Gene Identifier URL` key-value pair will be hidden.
+Mapr can automatically convert URLs into favicon links.
+To use this feature the key such as `Gene Identifier` must be in the "all" list of a config
+as shown above and the `Gene Identifier` key-value pair must be followed by a key-value pair
+called `Gene Identifier URL`.
+A favicon linked to the external URL will be appended to the `Gene Identifier` row, and the
+`Gene Identifier URL` key-value pair will be hidden.
+OMERO.web must be configured with the Django redis cache
+https://docs.openmicroscopy.org/omero/5/sysadmins/unix/install-web/walkthrough/omeroweb-install-centos7-ice3.6.html?highlight=redis#configuring-omero-web
+which is used to cache the favicons that are obtained using a Google service.
 
 
 Testing

--- a/omero_mapr/mapr_settings.py
+++ b/omero_mapr/mapr_settings.py
@@ -40,7 +40,12 @@ MAPR_SETTINGS_MAPPING = {
          str, None],
     "omero.web.mapr.favicon_webservice":
         ["MAPR_FAVICON_WEBSERVICE",
-            "http://www.google.com/s2/favicons?domain=", str, None],
+            "http://www.google.com/s2/favicons?domain=", str,
+            (
+                "Service to load favicons for use in external links."
+                " Icons are cached in redis which must be available."
+            )
+        ],
     }
 
 

--- a/omero_mapr/mapr_settings.py
+++ b/omero_mapr/mapr_settings.py
@@ -45,7 +45,7 @@ MAPR_SETTINGS_MAPPING = {
                 "Service to load favicons for use in external links."
                 " Icons are cached in redis which must be available."
             )
-        ],
+         ],
     }
 
 

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -54,7 +54,7 @@ var iconify = function(input, imgsrc) {
     if (typeof imgsrc === 'undefined') {
         // e.g. https://www.google.com/s2/favicons?domain=https://www.ensembl.org/index.html
         // mapr can store icon in redis and serve at
-        // e.g http://idr.openmicroscopy.org/mapr/favicon/?u=https://www.ensembl.org/index.html
+        // e.g https://idr.openmicroscopy.org/mapr/favicon/?u=https://www.ensembl.org/index.html
         imgsrc = "{% url "mapannotations_favicon" %}?u=";
     }
     function replacer(match){

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -137,10 +137,10 @@ OME.linkify_element = function(elements) {
                             );
                         }).closest("tr");
                         // Fall back to using the previous row
-                        if ( !$target ) {
+                        if ( !$target.length ) {
                             $target = $row.prev('tr');
                         }
-                        if ( $target ) {
+                        if ( $target.length ) {
                             var $targetchlabel = $target.children("td:nth-child(1)");
                             var $targetchvalue = $target.children("td:nth-child(2)");
                             // add icon to the target and hide

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -122,7 +122,19 @@ OME.linkify_element = function(elements) {
                             var $chl = $(this).children("td:nth-child(1)");
                             var $chv = $(this).children("td:nth-child(2)");
                             var $chs = $row.children("td:nth-child(2)").find("span a img").attr('src');
-                            return $chl.text() === _tkey && (($chv.find("a").text().lenght > 0 && ($chs.indexOf(encodeURIComponent($chv.find("a").text())) >= 0 || $chs.indexOf($chv.find("a").text()) >= 0)) || ($chv.text().length > 0 && ($chs.indexOf(encodeURIComponent($chv.text())) >= 0 || $chs.indexOf($chv.text()) >= 0)));
+                            return
+                                $chl.text() === _tkey &&
+                                (
+                                    (
+                                        $chv.find("a").text().lenght > 0 &&
+                                        (
+                                            $chs.indexOf(encodeURIComponent($chv.find("a").text())) >= 0 ||
+                                            $chs.indexOf($chv.find("a").text()) >= 0
+                                        )
+                                    ) || ($chv.text().length > 0 &&
+                                        ($chs.indexOf(encodeURIComponent($chv.text())) >= 0 || $chs.indexOf($chv.text()) >= 0)
+                                    )
+                                );
                         }).closest("tr");
                         if ( $target.length ) {
                             var $targetchlabel = $target.children("td:nth-child(1)");

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -102,46 +102,28 @@ OME.linkify_element = function(elements) {
             if (!$row.parent().parent().hasClass("editableKeyValueTable")) {
                 var $chlabel = $row.children("td:nth-child(1)");
                 var $chvalue = $row.children("td:nth-child(2)");
-                // if label matchs mapr PK
                 var _key = $chlabel.text().trim();
                 var _val = $chvalue.text().trim();
                 var _tkey = _key.replace(/url/i, "").trim();
+                // Look for K-V pairs where the label is
+                // '<mapr-PK>' or '<mapr-PK> URL'
                 if ( $.inArray(_tkey, menu2keys) > -1  ) {
+                    // Create a linked favicon for the external resource
                     $chvalue.html(iconify($chvalue.text()));
                     if ( $.inArray(_key, menu2keys) > -1 ) {
                         if ( _key in keys2menu && keys2menu[_key] !== undefined ) {
-                            // create mapr url
+                            // Internal mapr URL for the value
                             var _url = location.protocol + "//" + location.host + "{% url 'maprindex' %}" + keys2menu[_key] +"/?value=" + encodeURIComponent(_val);
                             $chvalue.html($chvalue.html().replace(_val, '<a href="' + _url + '">' + _val + '</a>'));
                         }
                     }
                     if ( _key.match(new RegExp("url", "i"))  ) {
-                        // Find nearest URL containing the mapr value
-                        var $target = $row.parent().find("tr").filter(function() {
-                            var $chl = $(this).children("td:nth-child(1)");
-                            var $chv = $(this).children("td:nth-child(2)");
-                            var $chs = $row.children("td:nth-child(2)").find("span a img").attr('src');
-                            return (
-                                $chl.text() === _tkey &&
-                                (
-                                    (
-                                        $chv.find("a").text().length > 0 &&
-                                        (
-                                            $chs.indexOf(encodeURIComponent($chv.find("a").text())) >= 0 ||
-                                            $chs.indexOf($chv.find("a").text()) >= 0
-                                        )
-                                    ) || ($chv.text().length > 0 &&
-                                        ($chs.indexOf(encodeURIComponent($chv.text())) >= 0 || $chs.indexOf($chv.text()) >= 0)
-                                    )
-                                )
-                            );
-                        }).closest("tr");
-                        // Fall back to using the previous row
-                        if ( !$target.length ) {
-                            $target = $row.prev('tr');
-                        }
-                        if ( $target.length ) {
-                            var $targetchlabel = $target.children("td:nth-child(1)");
+                        // Associate with the previous row as long as
+                        // row[N-1].key == row[N].key + ' URL'
+                        var $target = $row.prev('tr');
+                        if ( $target.length &&
+                             $target.children("td:nth-child(1)").text() === _tkey
+                        ) {
                             var $targetchvalue = $target.children("td:nth-child(2)");
                             // add icon to the target and hide
                             $targetchvalue.append($chvalue.html());

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -116,8 +116,7 @@ OME.linkify_element = function(elements) {
                         }
                     }
                     if ( _key.match(new RegExp("url", "i"))  ) {
-                        // Find nearest URL
-                        //var $target1 = $row.prev('tr');
+                        // Find nearest URL containing the mapr value
                         var $target = $row.parent().find("tr").filter(function() {
                             var $chl = $(this).children("td:nth-child(1)");
                             var $chv = $(this).children("td:nth-child(2)");
@@ -136,7 +135,11 @@ OME.linkify_element = function(elements) {
                                     )
                                 );
                         }).closest("tr");
-                        if ( $target.length ) {
+                        // Fall back to using the previous row
+                        if ( !$target ) {
+                            $target = $row.prev('tr');
+                        }
+                        if ( $target ) {
                             var $targetchlabel = $target.children("td:nth-child(1)");
                             var $targetchvalue = $target.children("td:nth-child(2)");
                             // add icon to the target and hide

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -126,7 +126,7 @@ OME.linkify_element = function(elements) {
                                 $chl.text() === _tkey &&
                                 (
                                     (
-                                        $chv.find("a").text().lenght > 0 &&
+                                        $chv.find("a").text().length > 0 &&
                                         (
                                             $chs.indexOf(encodeURIComponent($chv.find("a").text())) >= 0 ||
                                             $chs.indexOf($chv.find("a").text()) >= 0

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -126,12 +126,13 @@ OME.linkify_element = function(elements) {
                     }
                     // If we're on e.g. "Gene Identifier URL" row...
                     if ( _key.match(new RegExp("url", "i"))  ) {
-                        // Associate with the previous row as long as
+                        // Find the next previous row where
                         // row[N-1].key == row[N].key + ' URL'
                         var $target = $row.prev('tr');
-                        if ( $target.length &&
-                             $target.children("td:nth-child(1)").text() === _tkey
-                        ) {
+                        while ($target.length > 0 && $target.children("td:nth-child(1)").text() !== _tkey) {
+                            $target = $target.prev('tr');
+                        }
+                        if ($target.children("td:nth-child(1)").text() === _tkey) {
                             var $targetchvalue = $target.children("td:nth-child(2)");
                             // Take the Favicon html we created with iconify() above
                             // and add it to the previous Value. Then hide this row.

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -121,7 +121,7 @@ OME.linkify_element = function(elements) {
                             var $chl = $(this).children("td:nth-child(1)");
                             var $chv = $(this).children("td:nth-child(2)");
                             var $chs = $row.children("td:nth-child(2)").find("span a img").attr('src');
-                            return
+                            return (
                                 $chl.text() === _tkey &&
                                 (
                                     (
@@ -133,7 +133,8 @@ OME.linkify_element = function(elements) {
                                     ) || ($chv.text().length > 0 &&
                                         ($chs.indexOf(encodeURIComponent($chv.text())) >= 0 || $chs.indexOf($chv.text()) >= 0)
                                     )
-                                );
+                                )
+                            );
                         }).closest("tr");
                         // Fall back to using the previous row
                         if ( !$target ) {

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -52,7 +52,9 @@ var urlRegex = new RegExp("(https?|ftp|file):\/\/[!-~]*", "igm");
 
 var iconify = function(input, imgsrc) {
     if (typeof imgsrc === 'undefined') {
-        //imgsrc = 'http://www.google.com/s2/favicons?domain=';
+        // e.g. https://www.google.com/s2/favicons?domain=https://www.ensembl.org/index.html
+        // mapr can store icon in redis and serve at
+        // e.g http://idr.openmicroscopy.org/mapr/favicon/?u=https://www.ensembl.org/index.html
         imgsrc = "{% url "mapannotations_favicon" %}?u=";
     }
     function replacer(match){
@@ -88,15 +90,17 @@ OME.linkify_element = function(elements) {
         });
 
         // linkify also mapr keys and convert URL to icons
-        var menu2keys = [];
+        // Dict of {'Key Name': 'maprConfigId'}
         var keys2menu = {};
-        $.each( mapr_menu, function( i, obj ) {
-            $.merge(menu2keys, obj['all']);
-            $.each( obj['all'], function( j, d ) {
-                keys2menu[d] = i
+        $.each( mapr_menu, function( configId, config ) {
+            $.each( config['all'], function( j, maprKey ) {
+                // some configs support multiple Keys in 'all'
+                keys2menu[maprKey] = configId
             });
         });
+        let menu2keys = Object.keys(keys2menu);
 
+        // Look for rows that...
         elements.find("tbody").find("tr").each(function() {
             var $row = $(this);
             if (!$row.parent().parent().hasClass("editableKeyValueTable")) {
@@ -107,16 +111,20 @@ OME.linkify_element = function(elements) {
                 var _tkey = _key.replace(/url/i, "").trim();
                 // Look for K-V pairs where the label is
                 // '<mapr-PK>' or '<mapr-PK> URL'
+                // Will be true for 'Gene Indentifier' and 'Gene Indentifier URL'
                 if ( $.inArray(_tkey, menu2keys) > -1  ) {
-                    // Create a linked favicon for the external resource
+                    // IF the value is a URL, create a favicon
                     $chvalue.html(iconify($chvalue.text()));
+                    // If the key is named in any mapr config,
+                    // E.g. _key is "Gene Symbol" or "Gene Identifier" for "gene" mapr config
                     if ( $.inArray(_key, menu2keys) > -1 ) {
                         if ( _key in keys2menu && keys2menu[_key] !== undefined ) {
-                            // Internal mapr URL for the value
+                            // Make Value into link to Internal mapr URL for the value, e.g. .../mapr/gene/?value=CDK5RAP2
                             var _url = location.protocol + "//" + location.host + "{% url 'maprindex' %}" + keys2menu[_key] +"/?value=" + encodeURIComponent(_val);
                             $chvalue.html($chvalue.html().replace(_val, '<a href="' + _url + '">' + _val + '</a>'));
                         }
                     }
+                    // If we're on e.g. "Gene Identifier URL" row...
                     if ( _key.match(new RegExp("url", "i"))  ) {
                         // Associate with the previous row as long as
                         // row[N-1].key == row[N].key + ' URL'
@@ -125,7 +133,8 @@ OME.linkify_element = function(elements) {
                              $target.children("td:nth-child(1)").text() === _tkey
                         ) {
                             var $targetchvalue = $target.children("td:nth-child(2)");
-                            // add icon to the target and hide
+                            // Take the Favicon html we created with iconify() above
+                            // and add it to the previous Value. Then hide this row.
                             $targetchvalue.append($chvalue.html());
                             $row.hide();
                         }

--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -111,7 +111,7 @@ OME.linkify_element = function(elements) {
                 var _tkey = _key.replace(/url/i, "").trim();
                 // Look for K-V pairs where the label is
                 // '<mapr-PK>' or '<mapr-PK> URL'
-                // Will be true for 'Gene Indentifier' and 'Gene Indentifier URL'
+                // Will be true for 'Gene Identifier' and 'Gene Identifier URL'
                 if ( $.inArray(_tkey, menu2keys) > -1  ) {
                     // IF the value is a URL, create a favicon
                     $chvalue.html(iconify($chvalue.text()));

--- a/omero_mapr/tree.py
+++ b/omero_mapr/tree.py
@@ -42,8 +42,8 @@ logger = logging.getLogger(__name__)
 
 def _escape_chars_like(query):
     escape_chars = {
-        "%": "\%",
-        "_": "\_",
+        "%": r"\%",
+        "_": r"\_",
     }
 
     for k, v in escape_chars.items():


### PR DESCRIPTION
Deployed on the idr0094 server

A mapr key of the form `xxx URL` is now only matched with a preceding row with key `xxx`. This is a change to the previous behaviour where all(?) rows were searched for a matching substring value.

Closes https://github.com/ome/omero-mapr/issues/62