### PR TITLE
Query string IDs

### DIFF
--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -175,19 +175,29 @@ $(function () {
         }
         if (selected.length > 1) {
             // handle batch annotation...
-            var productListQuery = new Array();
-            var well_index;
-            for (var i=0; i<selected.length; i++) {
-                productListQuery[i] = selected[i]["id"].replace("-","=");
-                well_index = well_index || selected[i]["index"];
-            }
-            var query = '{% url 'batch_annotate' %}'+"?"+productListQuery.join("&");
+            // dict of {'type': ids}
+            let well_index;
+            let typeIds = selected.reduce(function (prev, s) {
+                well_index = well_index || s.index;
+                let dtype = s.id.split('-')[0];
+                let objId = s.id.split('-')[1];
+                if (!prev[dtype]) {
+                    prev[dtype] = [];
+                }
+                prev[dtype].push(objId);
+                return prev;
+            }, {});
+            // query = 'image=1,2,3&dataset=4,5,6'
+            var query = Object.keys(typeIds).map(dtype => {
+                return dtype + '=' + typeIds[dtype].join(',');
+            }).join('&');
             if (well_index) {
                 query += "&index=" + well_index;
             }
+            var url = '{% url 'batch_annotate' %}' + "?" + query;
             // Load right hand panel...
             $.ajax({
-                url: query,
+                url,
                 dataType: "html",
                 // Need to check that the selected objects haven't changed during AJAX call...
                 success: function(data) {


### PR DESCRIPTION
Use ?image=1,2,3 to load batch_annotate panel

This ports the changes from https://github.com/ome/omero-web/pull/225
so that those changes are not overridden when mapr is installed.

To test, with mapr installed, select multiple images in centre panel.
URL that loads batch_annotate panel should contain image IDs in the form ?image=1,2,3
This will work when e.g. 500 images are selected. Without this fix, the URL query string of the form ?image=1&image=2... etc is too long with 500 images.

cc @manics 