### PR TITLE
Include sizeT in _marshal_image() row

### DIFF
--- a/omero_mapr/tree.py
+++ b/omero_mapr/tree.py
@@ -745,7 +745,8 @@ def marshal_images(conn, parent, parent_id,
             ,
             pix.sizeX as sizeX,
             pix.sizeY as sizeY,
-            pix.sizeZ as sizeZ
+            pix.sizeZ as sizeZ,
+            pix.sizeT as sizeT
         """)
 
     if date:
@@ -809,7 +810,7 @@ def marshal_images(conn, parent, parent_id,
              e["filesetId"]]
         kwargs = {'conn': conn, 'row': d[0:5]}
         if load_pixels:
-            d = [e["sizeX"], e["sizeY"], e["sizeZ"]]
+            d = [e["sizeX"], e["sizeY"], e["sizeZ"], e["sizeT"]]
             kwargs['row_pixels'] = d
         if date:
             kwargs['acqDate'] = e['acqDate']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
 django-redis>4.4,<4.9
-omero-web>=5.6.0
+omero-web>=5.13.0


### PR DESCRIPTION
This fixes a breaking change from https://github.com/ome/omero-web/pull/329
where `omeroweb.webclient.tree._marshal_image()` expects a row with 4 values (`sizeT` was added in PR above).

To test:

 - Search in mapr tab. e.g for Gene.
 - Browse Project / Dataset and expand to load Images
 - Images should load instead of error:

![Screenshot 2022-02-22 at 10 21 56](https://user-images.githubusercontent.com/900055/155112726-3976e36f-9671-4842-8ff7-f2cbfe43debd.png)

cc @sbesson @francesw - We need to get this included in next IDR release (which includes omero-web PR above).
