### PR TITLE
Fix auto-complete css for omero-web 5.18.0 jquery-ui 1.13.2

### DIFF
--- a/omero_mapr/static/mapr/css/ome.mapr.css
+++ b/omero_mapr/static/mapr/css/ome.mapr.css
@@ -30,6 +30,12 @@ ul.ui-autocomplete{
     display: block;
 }
 
+/* removed in jquery-ui 1.13.2, but we still want this */
+.ui-menu-item a.ui-state-active {
+    background: #D4D6D8;
+    margin: 0;
+}
+
 #autocompletesearch {
     /* override .filtersearch width from webclient */
     width: 180px;

--- a/omero_mapr/static/mapr/css/ome.mapr.css
+++ b/omero_mapr/static/mapr/css/ome.mapr.css
@@ -26,6 +26,8 @@ ul.ui-autocomplete{
     background:#ffffff;
     font-size: 10px;
     width: 135px;
+    /* https://github.com/ome/omero-web/pull/433#issuecomment-1396774881 */
+    display: block;
 }
 
 #autocompletesearch {


### PR DESCRIPTION
Fixes #75

To test on merge-ci: click on 'Genes' link an type in mapr search - Auto-complete issue at https://github.com/ome/omero-web/pull/433#issuecomment-1396774881 should be fixed.