### PR TITLE
fix return of default favicon if not found

### DIFF
--- a/omero_mapr/views.py
+++ b/omero_mapr/views.py
@@ -673,10 +673,11 @@ def mapannotations_favicon(request, conn=None, **kwargs):
                     cache.hset('favdomain', _cache_key, icon)
             finally:
                 r.connection.close()
-        return HttpJPEGResponse(icon)
+        if icon is not None:
+            return HttpJPEGResponse(icon)
 
     with Image.open(mapr_settings.DEFAULT_FAVICON) as img:
-        img.thumbnail((16, 16), Image.ANTIALIAS)
+        img.thumbnail((16, 16))
         f = BytesIO()
         img.save(f, "PNG")
         f.seek(0)


### PR DESCRIPTION
Fixes return of default favicon if one is not loaded from domain.

cc @francesw 

To test, go to e.g. /mapr/favicon/?u=https%3A%2F%2Flod.humanatlas.io%2Fomap%2F18-lymph-node-cell-dive-ibex%2Fv1.0%2F and you should see a tiny globe icon shown on the page.