### PR TITLE
Replace omero utils

### DIFF
--- a/.omeroci/app-deps
+++ b/.omeroci/app-deps
@@ -4,4 +4,4 @@ set -e
 set -u
 
 # for test setup
-/opt/omero/web/venv3/bin/pip3 install Jinja2
+/opt/omero/web/venv3/bin/pip3 install omero-metadata

--- a/omero_mapr/testlib/__init__.py
+++ b/omero_mapr/testlib/__init__.py
@@ -26,8 +26,8 @@
 from omero.model import ScreenI
 from omero.rtypes import rstring, unwrap
 from omero.constants.namespaces import NSBULKANNOTATIONS
-from omero.util.populate_metadata import BulkToMapAnnotationContext
-from omero.util.populate_metadata import ParsingContext
+from omero_metadata.populate import BulkToMapAnnotationContext
+from omero_metadata.populate import ParsingContext
 
 from omeroweb.testlib import IWebTest
 
@@ -97,7 +97,6 @@ class IMaprTest(IWebTest):
 
         ctx = ParsingContext(self.client, self.screen.proxy(), file=csv)
         ctx.parse()
-        ctx.write_to_omero()
 
         # Get file annotations
         anns = self.get_screen_annotations()
@@ -110,4 +109,3 @@ class IMaprTest(IWebTest):
         ctx = BulkToMapAnnotationContext(
             self.client, self.screen.proxy(), fileid=fileid, cfg=cfg)
         ctx.parse()
-        ctx.write_to_omero()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,4 +2,4 @@ pytest==3.3.2
 pytest-django==3.1.2
 pytest-runner==3.0.1
 PyYAML
-Jinja2
+omero-metadata


### PR DESCRIPTION
With the new release of omero-metadata (0.13.0), ``omero.util`` can be replaced by ``omero-metadata``
